### PR TITLE
(fix): Use npm to install deps in ci.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 build:
-	npm install -g yarn
-	yarn
-	yarn build
+	npm install -g npm@6.0.0
+	npm ci
+	npm run build

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,18 @@
+# Deploying Peerpad
+
+The [`ci/Jenkinsfile`]() defines what domain to deploy the app under, and that the `/build` directory is where it should look for
+
+The `build` target defined in the [Makefile](../Makefile) is executed on Jenkins on every PR and merge to master. It installs the dependencies, and runs the `npm run build` script defined in the `package.json` is run.
+
+That calls [`scripts/build.js`](../scripts/build.js) which creates the optimised build into the `build/` directory. That script is the result of ejecting a create-react-app generated scaffolding. It's been tweaked to disable mangling, though that may no longer be necessary (https://github.com/ipfs/aegir/pull/214)
+
+Jenkins CI build peerpad as a "website" job. The build is executed in a docker container:
+
+```sh
+sh 'docker run -i -v `pwd`:/site ipfs/ci-websites make -C /site build'
+```
+https://github.com/ipfs/jenkins-libs/blob/796cab23030077109f98bbb092d57ed9f4964772/vars/website.groovy#L80
+
+The ipfs/ci-websites docker image is built from this Dockefile, which defines the build environment https://github.com/ipfs/ci-websites/blob/af0b98f712a5e6bd4174eb86e2ee05c9bdaacb57/Dockerfile
+
+When a PR is merged to master, Jenkins will run the build steps in the Makefile, and if all goes well, add the build dir to ipfs, and update the dns for peerpad.net to point the `_dnslink` subdomain to the new root ipfs hash.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
       "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
       "requires": {
-        "xtend": "3.0.0"
+        "xtend": "~3.0.0"
       },
       "dependencies": {
         "xtend": {
@@ -35,8 +35,8 @@
       "resolved": "https://registry.npmjs.org/accept/-/accept-2.1.4.tgz",
       "integrity": "sha1-iHr1TO7lx/RDBGGXHsQAxh0JrLs=",
       "requires": {
-        "boom": "5.2.0",
-        "hoek": "4.2.0"
+        "boom": "5.x.x",
+        "hoek": "4.x.x"
       }
     },
     "accepts": {
@@ -44,7 +44,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "requires": {
-        "mime-types": "2.1.18",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
       },
       "dependencies": {
@@ -58,7 +58,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
           "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "requires": {
-            "mime-db": "1.33.0"
+            "mime-db": "~1.33.0"
           }
         }
       }
@@ -73,7 +73,7 @@
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
       "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "^4.0.3"
       },
       "dependencies": {
         "acorn": {
@@ -88,7 +88,7 @@
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
       "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "^4.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -103,7 +103,7 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -133,10 +133,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
       "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
-        "json-stable-stringify": "1.0.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "json-schema-traverse": "^0.3.0",
+        "json-stable-stringify": "^1.0.1"
       }
     },
     "ajv-keywords": {
@@ -149,9 +149,9 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "alphanum-sort": {
@@ -169,8 +169,8 @@
       "resolved": "https://registry.npmjs.org/ammo/-/ammo-2.0.4.tgz",
       "integrity": "sha1-v4CqshFpjqePY+9efxE91dnokX8=",
       "requires": {
-        "boom": "5.2.0",
-        "hoek": "4.2.0"
+        "boom": "5.x.x",
+        "hoek": "4.x.x"
       }
     },
     "anser": {
@@ -183,7 +183,7 @@
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "requires": {
-        "string-width": "2.1.1"
+        "string-width": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -201,8 +201,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -210,7 +210,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -235,7 +235,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
       "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
       "requires": {
-        "color-convert": "1.9.0"
+        "color-convert": "^1.9.0"
       }
     },
     "anymatch": {
@@ -243,8 +243,8 @@
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       }
     },
     "append-transform": {
@@ -252,7 +252,7 @@
       "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
       "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
       "requires": {
-        "default-require-extensions": "1.0.0"
+        "default-require-extensions": "^1.0.0"
       }
     },
     "aproba": {
@@ -265,8 +265,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "argparse": {
@@ -274,7 +274,7 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       },
       "dependencies": {
         "sprintf-js": {
@@ -297,7 +297,7 @@
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -330,8 +330,8 @@
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
       "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.8.2"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.7.0"
       }
     },
     "array-iterate": {
@@ -354,7 +354,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -392,9 +392,9 @@
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
       "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
       "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "assert": {
@@ -420,7 +420,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
       "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.14.0"
       },
       "dependencies": {
         "lodash": {
@@ -450,12 +450,12 @@
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.1.2.tgz",
       "integrity": "sha1-++rwfUj9h44Ggr98vurecorbKxg=",
       "requires": {
-        "browserslist": "2.4.0",
-        "caniuse-lite": "1.0.30000741",
-        "normalize-range": "0.1.2",
-        "num2fraction": "1.2.2",
-        "postcss": "6.0.12",
-        "postcss-value-parser": "3.3.0"
+        "browserslist": "^2.1.5",
+        "caniuse-lite": "^1.0.30000697",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^6.0.6",
+        "postcss-value-parser": "^3.2.3"
       }
     },
     "aws-sign2": {
@@ -486,9 +486,9 @@
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "babel-core": {
@@ -496,25 +496,25 @@
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
       "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.0",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.7",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.22.0",
+        "babel-generator": "^6.25.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.25.0",
+        "babel-traverse": "^6.25.0",
+        "babel-types": "^6.25.0",
+        "babylon": "^6.17.2",
+        "convert-source-map": "^1.1.0",
+        "debug": "^2.1.1",
+        "json5": "^0.5.0",
+        "lodash": "^4.2.0",
+        "minimatch": "^3.0.2",
+        "path-is-absolute": "^1.0.0",
+        "private": "^0.1.6",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.0"
       },
       "dependencies": {
         "debug": {
@@ -532,10 +532,10 @@
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
       "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0"
+        "babel-code-frame": "^6.22.0",
+        "babel-traverse": "^6.23.1",
+        "babel-types": "^6.23.0",
+        "babylon": "^6.17.0"
       }
     },
     "babel-generator": {
@@ -543,14 +543,14 @@
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.6",
+        "trim-right": "^1.0.1"
       },
       "dependencies": {
         "jsesc": {
@@ -565,9 +565,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-builder-react-jsx": {
@@ -575,9 +575,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
       "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "esutils": "2.0.2"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "esutils": "^2.0.2"
       }
     },
     "babel-helper-call-delegate": {
@@ -585,10 +585,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-define-map": {
@@ -596,10 +596,10 @@
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -607,9 +607,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-function-name": {
@@ -617,11 +617,11 @@
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-get-function-arity": {
@@ -629,8 +629,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-hoist-variables": {
@@ -638,8 +638,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -647,8 +647,8 @@
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-regex": {
@@ -656,9 +656,9 @@
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -666,11 +666,11 @@
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helper-replace-supers": {
@@ -678,12 +678,12 @@
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
       "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-helpers": {
@@ -691,8 +691,8 @@
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-jest": {
@@ -700,9 +700,9 @@
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-20.0.3.tgz",
       "integrity": "sha1-5KA7E9wQOJ4UD8ZF0J/8TO0wFnE=",
       "requires": {
-        "babel-core": "6.25.0",
-        "babel-plugin-istanbul": "4.1.5",
-        "babel-preset-jest": "20.0.3"
+        "babel-core": "^6.0.0",
+        "babel-plugin-istanbul": "^4.0.0",
+        "babel-preset-jest": "^20.0.3"
       }
     },
     "babel-loader": {
@@ -710,9 +710,9 @@
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.1.tgz",
       "integrity": "sha1-uHE0yLEuPkwqlOBUYIW8aAorhIg=",
       "requires": {
-        "find-cache-dir": "1.0.0",
-        "loader-utils": "1.1.0",
-        "mkdirp": "0.5.1"
+        "find-cache-dir": "^1.0.0",
+        "loader-utils": "^1.0.2",
+        "mkdirp": "^0.5.1"
       }
     },
     "babel-messages": {
@@ -720,7 +720,7 @@
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -728,7 +728,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-dynamic-import-node": {
@@ -736,9 +736,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-1.0.2.tgz",
       "integrity": "sha1-rbW8j0iokxFUA5WunwzD7UsQuy4=",
       "requires": {
-        "babel-plugin-syntax-dynamic-import": "6.18.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "babel-template": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-istanbul": {
@@ -746,9 +746,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz",
       "integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
       "requires": {
-        "find-up": "2.1.0",
-        "istanbul-lib-instrument": "1.8.0",
-        "test-exclude": "4.1.1"
+        "find-up": "^2.1.0",
+        "istanbul-lib-instrument": "^1.7.5",
+        "test-exclude": "^4.1.1"
       }
     },
     "babel-plugin-jest-hoist": {
@@ -801,9 +801,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-class-properties": {
@@ -811,10 +811,10 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
       "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-plugin-syntax-class-properties": "6.13.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-plugin-syntax-class-properties": "^6.8.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -822,7 +822,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -830,7 +830,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
@@ -838,11 +838,11 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -850,15 +850,15 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -866,8 +866,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -875,7 +875,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -883,8 +883,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -892,7 +892,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -900,9 +900,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -910,7 +910,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -918,9 +918,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -928,10 +928,10 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
       "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -939,9 +939,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
       "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -949,9 +949,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
       "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -959,8 +959,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
       "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -968,12 +968,12 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -981,8 +981,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -990,7 +990,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -998,9 +998,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -1008,7 +1008,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1016,7 +1016,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -1024,9 +1024,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -1034,9 +1034,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-flow-strip-types": {
@@ -1044,8 +1044,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
       "requires": {
-        "babel-plugin-syntax-flow": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-flow": "^6.18.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-object-rest-spread": {
@@ -1053,8 +1053,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
       "integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
       "requires": {
-        "babel-plugin-syntax-object-rest-spread": "6.13.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-constant-elements": {
@@ -1062,7 +1062,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-constant-elements/-/babel-plugin-transform-react-constant-elements-6.23.0.tgz",
       "integrity": "sha1-LxGb9NLN1F65uqrldAU8YE9hR90=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-display-name": {
@@ -1070,7 +1070,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
       "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-jsx": {
@@ -1078,9 +1078,9 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
       "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
       "requires": {
-        "babel-helper-builder-react-jsx": "6.26.0",
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-helper-builder-react-jsx": "^6.24.1",
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-jsx-self": {
@@ -1088,8 +1088,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
       "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
       "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-react-jsx-source": {
@@ -1097,8 +1097,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
       "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
       "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.26.0"
+        "babel-plugin-syntax-jsx": "^6.8.0",
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-regenerator": {
@@ -1106,7 +1106,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "requires": {
-        "regenerator-transform": "0.10.1"
+        "regenerator-transform": "^0.10.0"
       }
     },
     "babel-plugin-transform-runtime": {
@@ -1114,7 +1114,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-runtime/-/babel-plugin-transform-runtime-6.23.0.tgz",
       "integrity": "sha1-iEkNRGUC6puOfvsP4J7E2ZR5se4=",
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -1122,8 +1122,8 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
       }
     },
     "babel-preset-env": {
@@ -1131,36 +1131,36 @@
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.5.2.tgz",
       "integrity": "sha1-zUrpCm6Utwn5c3SzPl+LmDVWre8=",
       "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.4.0",
-        "invariant": "2.2.2",
-        "semver": "5.4.1"
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^2.1.2",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
       }
     },
     "babel-preset-flow": {
@@ -1168,7 +1168,7 @@
       "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
       "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
       "requires": {
-        "babel-plugin-transform-flow-strip-types": "6.22.0"
+        "babel-plugin-transform-flow-strip-types": "^6.22.0"
       }
     },
     "babel-preset-jest": {
@@ -1176,7 +1176,7 @@
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz",
       "integrity": "sha1-y6yq3stdaJyh4d4TYOv8ZoYsF4o=",
       "requires": {
-        "babel-plugin-jest-hoist": "20.0.3"
+        "babel-plugin-jest-hoist": "^20.0.3"
       }
     },
     "babel-preset-react": {
@@ -1184,12 +1184,12 @@
       "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
       "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
       "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-plugin-transform-react-display-name": "6.25.0",
-        "babel-plugin-transform-react-jsx": "6.24.1",
-        "babel-plugin-transform-react-jsx-self": "6.22.0",
-        "babel-plugin-transform-react-jsx-source": "6.22.0",
-        "babel-preset-flow": "6.23.0"
+        "babel-plugin-syntax-jsx": "^6.3.13",
+        "babel-plugin-transform-react-display-name": "^6.23.0",
+        "babel-plugin-transform-react-jsx": "^6.24.1",
+        "babel-plugin-transform-react-jsx-self": "^6.22.0",
+        "babel-plugin-transform-react-jsx-source": "^6.22.0",
+        "babel-preset-flow": "^6.23.0"
       }
     },
     "babel-preset-react-app": {
@@ -1224,9 +1224,9 @@
           "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
           "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "private": "0.1.7"
+            "babel-runtime": "^6.18.0",
+            "babel-types": "^6.19.0",
+            "private": "^0.1.6"
           }
         }
       }
@@ -1236,13 +1236,13 @@
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.1",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       },
       "dependencies": {
         "babel-core": {
@@ -1250,25 +1250,25 @@
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
           "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-generator": "6.26.0",
-            "babel-helpers": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-register": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "convert-source-map": "1.5.0",
-            "debug": "2.6.9",
-            "json5": "0.5.1",
-            "lodash": "4.17.4",
-            "minimatch": "3.0.4",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.7",
-            "slash": "1.0.0",
-            "source-map": "0.5.7"
+            "babel-code-frame": "^6.26.0",
+            "babel-generator": "^6.26.0",
+            "babel-helpers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-register": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "convert-source-map": "^1.5.0",
+            "debug": "^2.6.8",
+            "json5": "^0.5.1",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.4",
+            "path-is-absolute": "^1.0.1",
+            "private": "^0.1.7",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.6"
           }
         },
         "debug": {
@@ -1286,8 +1286,8 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
@@ -1295,11 +1295,11 @@
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -1307,15 +1307,15 @@
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       },
       "dependencies": {
         "debug": {
@@ -1333,10 +1333,10 @@
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -1364,7 +1364,7 @@
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
       "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "base32.js": {
@@ -1398,7 +1398,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bech32": {
@@ -1454,7 +1454,7 @@
       "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
       "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "bitcoin-ops": {
@@ -1467,21 +1467,21 @@
       "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-3.3.2.tgz",
       "integrity": "sha512-l5qqvbaK8wwtANPf6oEffykycg4383XgEYdia1rI7/JpGf1jfRWlOUCvx5TiTZS7kyIvY4j/UhIQ2urLsvGkzw==",
       "requires": {
-        "bech32": "1.1.3",
-        "bigi": "1.4.2",
-        "bip66": "1.1.5",
-        "bitcoin-ops": "1.4.1",
-        "bs58check": "2.1.1",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "ecurve": "1.0.6",
-        "merkle-lib": "2.0.10",
-        "pushdata-bitcoin": "1.0.1",
-        "randombytes": "2.0.5",
-        "safe-buffer": "5.1.1",
-        "typeforce": "1.12.0",
-        "varuint-bitcoin": "1.1.0",
-        "wif": "2.0.6"
+        "bech32": "^1.1.2",
+        "bigi": "^1.4.0",
+        "bip66": "^1.1.0",
+        "bitcoin-ops": "^1.3.0",
+        "bs58check": "^2.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.3",
+        "ecurve": "^1.0.0",
+        "merkle-lib": "^2.0.10",
+        "pushdata-bitcoin": "^1.0.1",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "typeforce": "^1.11.3",
+        "varuint-bitcoin": "^1.0.4",
+        "wif": "^2.0.1"
       }
     },
     "bl": {
@@ -1489,8 +1489,8 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
-        "readable-stream": "2.3.6",
-        "safe-buffer": "5.1.1"
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -1503,13 +1503,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -1517,7 +1517,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -1548,15 +1548,15 @@
       "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "http-errors": "1.6.2",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.15"
+        "type-is": "~1.6.15"
       },
       "dependencies": {
         "debug": {
@@ -1574,12 +1574,12 @@
       "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "requires": {
-        "array-flatten": "2.1.1",
-        "deep-equal": "1.0.1",
-        "dns-equal": "1.0.0",
-        "dns-txt": "2.0.2",
-        "multicast-dns": "6.1.1",
-        "multicast-dns-service-types": "1.1.0"
+        "array-flatten": "^2.1.0",
+        "deep-equal": "^1.0.1",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.2",
+        "multicast-dns": "^6.0.1",
+        "multicast-dns-service-types": "^1.1.0"
       }
     },
     "boolbase": {
@@ -1592,7 +1592,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
       "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "bootstrap": {
@@ -1605,10 +1605,10 @@
       "resolved": "https://registry.npmjs.org/borc/-/borc-2.0.2.tgz",
       "integrity": "sha1-jq4aTVmc/f38n6hXy7ppyQ6DKR8=",
       "requires": {
-        "bignumber.js": "3.0.1",
-        "commander": "2.11.0",
-        "ieee754": "1.1.8",
-        "json-text-sequence": "0.1.1"
+        "bignumber.js": "~3.0.0",
+        "commander": "^2.9",
+        "ieee754": "^1.1.8",
+        "json-text-sequence": "^0.1"
       }
     },
     "boxen": {
@@ -1616,13 +1616,13 @@
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "requires": {
-        "ansi-align": "2.0.0",
-        "camelcase": "4.1.0",
-        "chalk": "2.4.1",
-        "cli-boxes": "1.0.0",
-        "string-width": "2.1.1",
-        "term-size": "1.2.0",
-        "widest-line": "2.0.0"
+        "ansi-align": "^2.0.0",
+        "camelcase": "^4.0.0",
+        "chalk": "^2.0.1",
+        "cli-boxes": "^1.0.0",
+        "string-width": "^2.0.0",
+        "term-size": "^1.2.0",
+        "widest-line": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1635,7 +1635,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -1643,9 +1643,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "has-flag": {
@@ -1663,8 +1663,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -1672,7 +1672,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -1680,7 +1680,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "widest-line": {
@@ -1688,7 +1688,7 @@
           "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
           "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
           "requires": {
-            "string-width": "2.1.1"
+            "string-width": "^2.1.1"
           }
         }
       }
@@ -1698,7 +1698,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1707,9 +1707,9 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "brorand": {
@@ -1737,12 +1737,12 @@
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.8.tgz",
       "integrity": "sha512-WYCMOT/PtGTlpOKFht0YJFYcPy6pLCR98CtWfzK13zoynLlBMvAdEMSRGmgnJCw2M2j/5qxBkinZQFobieM8dQ==",
       "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "browserify-cipher": {
@@ -1750,9 +1750,9 @@
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "requires": {
-        "browserify-aes": "1.0.8",
-        "browserify-des": "1.0.0",
-        "evp_bytestokey": "1.0.3"
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
       }
     },
     "browserify-des": {
@@ -1760,9 +1760,9 @@
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
       "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3"
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "browserify-rsa": {
@@ -1770,8 +1770,8 @@
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.5"
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
       }
     },
     "browserify-sha3": {
@@ -1779,7 +1779,7 @@
       "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.1.tgz",
       "integrity": "sha1-P/NKMAbvFcD7NWflQbkaI0ASPRE=",
       "requires": {
-        "js-sha3": "0.3.1"
+        "js-sha3": "^0.3.1"
       },
       "dependencies": {
         "js-sha3": {
@@ -1794,13 +1794,13 @@
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.0"
+        "bn.js": "^4.1.1",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.2",
+        "elliptic": "^6.0.0",
+        "inherits": "^2.0.1",
+        "parse-asn1": "^5.0.0"
       }
     },
     "browserify-zlib": {
@@ -1808,7 +1808,7 @@
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
       "requires": {
-        "pako": "0.2.9"
+        "pako": "~0.2.0"
       },
       "dependencies": {
         "pako": {
@@ -1823,8 +1823,8 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.4.0.tgz",
       "integrity": "sha512-aM2Gt4x9bVlCUteADBS6JP0F+2tMWKM1jQzUulVROtdFWFIcIVvY76AJbr7GDqy0eDhn+PcnpzzivGxY4qiaKQ==",
       "requires": {
-        "caniuse-lite": "1.0.30000741",
-        "electron-to-chromium": "1.3.24"
+        "caniuse-lite": "^1.0.30000718",
+        "electron-to-chromium": "^1.3.18"
       }
     },
     "bs58": {
@@ -1832,7 +1832,7 @@
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
       "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
       "requires": {
-        "base-x": "3.0.2"
+        "base-x": "^3.0.2"
       },
       "dependencies": {
         "base-x": {
@@ -1840,7 +1840,7 @@
           "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.2.tgz",
           "integrity": "sha1-v4c4YbdRQnm3lp80CSnquHwR0TA=",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "safe-buffer": {
@@ -1855,8 +1855,8 @@
       "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.1.tgz",
       "integrity": "sha512-okRQiWc5FJuA2VOwQ1hB7Sf0MyEFg/EwRN12h4b8HrJoGkZ3xq1CGjkaAfYloLcZyqixQnO5mhPpN6IcHSplVg==",
       "requires": {
-        "bs58": "4.0.1",
-        "create-hash": "1.1.3"
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0"
       }
     },
     "bser": {
@@ -1864,7 +1864,7 @@
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
       "requires": {
-        "node-int64": "0.4.0"
+        "node-int64": "^0.4.0"
       }
     },
     "buffer": {
@@ -1872,9 +1872,9 @@
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
-        "base64-js": "1.2.1",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-alloc": {
@@ -1882,8 +1882,8 @@
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.1.0.tgz",
       "integrity": "sha1-BVFNM78WVtNUDGhPZbEgLpDsowM=",
       "requires": {
-        "buffer-alloc-unsafe": "0.1.1",
-        "buffer-fill": "0.1.1"
+        "buffer-alloc-unsafe": "^0.1.0",
+        "buffer-fill": "^0.1.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -1921,7 +1921,7 @@
       "resolved": "https://registry.npmjs.org/buffer-split/-/buffer-split-1.0.0.tgz",
       "integrity": "sha1-RCfb/1NzG2HXpxq6R/UDOWYTeEo=",
       "requires": {
-        "buffer-indexof": "0.0.2"
+        "buffer-indexof": "~0.0.0"
       }
     },
     "buffer-xor": {
@@ -1954,19 +1954,19 @@
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.0.tgz",
       "integrity": "sha512-s9h6I9NY3KcBjfuS28K6XNmrv/HNFSzlpVD6eYMXugZg3Y8jjI1lUzTeUMa0oKByCDtHfsIy5Ec7KgWRnC5gtg==",
       "requires": {
-        "bluebird": "3.5.0",
-        "chownr": "1.0.1",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "lru-cache": "4.1.1",
-        "mississippi": "1.3.0",
-        "mkdirp": "0.5.1",
-        "move-concurrently": "1.0.1",
-        "promise-inflight": "1.0.1",
-        "rimraf": "2.6.2",
-        "ssri": "5.0.0",
-        "unique-filename": "1.1.0",
-        "y18n": "3.2.1"
+        "bluebird": "^3.5.0",
+        "chownr": "^1.0.1",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "lru-cache": "^4.1.1",
+        "mississippi": "^1.3.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.1",
+        "ssri": "^5.0.0",
+        "unique-filename": "^1.1.0",
+        "y18n": "^3.2.1"
       },
       "dependencies": {
         "rimraf": {
@@ -1974,7 +1974,7 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         }
       }
@@ -1984,8 +1984,8 @@
       "resolved": "https://registry.npmjs.org/call/-/call-4.0.2.tgz",
       "integrity": "sha1-33b19R7o3Ui4VqyEAPfmnm1zmcQ=",
       "requires": {
-        "boom": "5.2.0",
-        "hoek": "4.2.0"
+        "boom": "5.x.x",
+        "hoek": "4.x.x"
       }
     },
     "caller-path": {
@@ -1993,7 +1993,7 @@
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsite": {
@@ -2011,8 +2011,8 @@
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
       "requires": {
-        "no-case": "2.3.2",
-        "upper-case": "1.1.3"
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
       }
     },
     "camelcase": {
@@ -2025,8 +2025,8 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -2041,10 +2041,10 @@
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000741",
-        "lodash.memoize": "4.1.2",
-        "lodash.uniq": "4.5.0"
+        "browserslist": "^1.3.6",
+        "caniuse-db": "^1.0.30000529",
+        "lodash.memoize": "^4.1.2",
+        "lodash.uniq": "^4.5.0"
       },
       "dependencies": {
         "browserslist": {
@@ -2052,8 +2052,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000741",
-            "electron-to-chromium": "1.3.24"
+            "caniuse-db": "^1.0.30000639",
+            "electron-to-chromium": "^1.2.7"
           }
         }
       }
@@ -2088,9 +2088,9 @@
       "resolved": "https://registry.npmjs.org/catbox/-/catbox-7.1.5.tgz",
       "integrity": "sha512-4fui5lELzqZ+9cnaAP/BcqXTH6LvWLBRtFhJ0I4FfgfXiSaZcf6k9m9dqOyChiTxNYtvLk7ZMYSf7ahMq3bf5A==",
       "requires": {
-        "boom": "5.2.0",
-        "hoek": "4.2.0",
-        "joi": "10.6.0"
+        "boom": "5.x.x",
+        "hoek": "4.x.x",
+        "joi": "10.x.x"
       },
       "dependencies": {
         "joi": {
@@ -2098,10 +2098,10 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
           "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
           "requires": {
-            "hoek": "4.2.0",
-            "isemail": "2.2.1",
-            "items": "2.1.1",
-            "topo": "2.0.2"
+            "hoek": "4.x.x",
+            "isemail": "2.x.x",
+            "items": "2.x.x",
+            "topo": "2.x.x"
           }
         }
       }
@@ -2111,7 +2111,7 @@
       "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-2.0.4.tgz",
       "integrity": "sha1-Qz4lWQLK9UIz0ShkKcj03xToItU=",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "ccount": {
@@ -2124,8 +2124,8 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -2133,11 +2133,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2178,12 +2178,12 @@
       "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
       "dev": true,
       "requires": {
-        "css-select": "1.2.0",
-        "dom-serializer": "0.1.0",
-        "entities": "1.1.1",
-        "htmlparser2": "3.9.2",
-        "lodash": "4.17.4",
-        "parse5": "3.0.2"
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash": "^4.15.0",
+        "parse5": "^3.0.1"
       }
     },
     "chokidar": {
@@ -2191,15 +2191,15 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.2",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       }
     },
     "chownr": {
@@ -2217,9 +2217,9 @@
       "resolved": "https://registry.npmjs.org/cids/-/cids-0.5.3.tgz",
       "integrity": "sha512-ujWbNP8SeLKg5KmGrxYZM4c+ttd+wwvegrdtgmbi2KNFUbQN4pqsGZaGQE3rhjayXTbKFq36bYDbKhsnD0eMsg==",
       "requires": {
-        "multibase": "0.4.0",
-        "multicodec": "0.2.6",
-        "multihashes": "0.4.13"
+        "multibase": "~0.4.0",
+        "multicodec": "~0.2.6",
+        "multihashes": "~0.4.13"
       }
     },
     "cipher-base": {
@@ -2227,8 +2227,8 @@
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "circular-json": {
@@ -2241,7 +2241,7 @@
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
       "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
       "requires": {
-        "chalk": "1.1.3"
+        "chalk": "^1.1.3"
       }
     },
     "clean-css": {
@@ -2249,7 +2249,7 @@
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.9.tgz",
       "integrity": "sha1-Nc7ornaHpJuYA09w3gDE7dOCYwE=",
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "0.5.x"
       }
     },
     "cli-boxes": {
@@ -2262,7 +2262,7 @@
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-width": {
@@ -2275,9 +2275,9 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wrap-ansi": "2.1.0"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
       }
     },
     "clone": {
@@ -2295,7 +2295,7 @@
       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
       "requires": {
-        "q": "1.5.0"
+        "q": "^1.1.2"
       }
     },
     "code-point-at": {
@@ -2318,9 +2318,9 @@
       "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
       "requires": {
-        "clone": "1.0.2",
-        "color-convert": "1.9.0",
-        "color-string": "0.3.0"
+        "clone": "^1.0.2",
+        "color-convert": "^1.3.0",
+        "color-string": "^0.3.0"
       }
     },
     "color-convert": {
@@ -2328,7 +2328,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -2341,7 +2341,7 @@
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.0.0"
       }
     },
     "colormin": {
@@ -2349,9 +2349,9 @@
       "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
       "requires": {
-        "color": "0.11.4",
+        "color": "^0.11.0",
         "css-color-names": "0.0.4",
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "colors": {
@@ -2365,7 +2365,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "comma-separated-tokens": {
@@ -2406,7 +2406,7 @@
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz",
       "integrity": "sha1-FnGKdd4oPtjmBAQWJaIGRYZ5fYo=",
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": ">= 1.29.0 < 2"
       }
     },
     "compression": {
@@ -2414,13 +2414,13 @@
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
       "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
       "requires": {
-        "accepts": "1.3.4",
+        "accepts": "~1.3.4",
         "bytes": "3.0.0",
-        "compressible": "2.0.11",
+        "compressible": "~2.0.11",
         "debug": "2.6.9",
-        "on-headers": "1.0.1",
+        "on-headers": "~1.0.1",
         "safe-buffer": "5.1.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "accepts": {
@@ -2428,7 +2428,7 @@
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
           "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
           "requires": {
-            "mime-types": "2.1.17",
+            "mime-types": "~2.1.16",
             "negotiator": "0.6.1"
           }
         },
@@ -2452,9 +2452,9 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "configstore": {
@@ -2462,12 +2462,12 @@
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "requires": {
-        "dot-prop": "4.2.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.0.0",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.3.0",
-        "xdg-basedir": "3.0.0"
+        "dot-prop": "^4.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^1.0.0",
+        "unique-string": "^1.0.0",
+        "write-file-atomic": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       }
     },
     "connect-history-api-fallback": {
@@ -2480,7 +2480,7 @@
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "console-control-strings": {
@@ -2503,7 +2503,7 @@
       "resolved": "https://registry.npmjs.org/content/-/content-3.0.7.tgz",
       "integrity": "sha512-LXtnSnvE+Z1Cjpa3P9gh9kb396qV4MqpfwKy777BOSF8n6nw2vAi03tHNl0/XRqZUyzVzY/+nMXOZVnEapWzdg==",
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       }
     },
     "content-disposition": {
@@ -2541,12 +2541,12 @@
       "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
       "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "requires": {
-        "aproba": "1.2.0",
-        "fs-write-stream-atomic": "1.0.10",
-        "iferr": "0.1.5",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
       },
       "dependencies": {
         "rimraf": {
@@ -2554,7 +2554,7 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         }
       }
@@ -2574,13 +2574,13 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
       "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
       "requires": {
-        "is-directory": "0.3.1",
-        "js-yaml": "3.7.0",
-        "minimist": "1.2.0",
-        "object-assign": "4.1.1",
-        "os-homedir": "1.0.2",
-        "parse-json": "2.2.0",
-        "require-from-string": "1.2.1"
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.4.3",
+        "minimist": "^1.2.0",
+        "object-assign": "^4.1.0",
+        "os-homedir": "^1.0.1",
+        "parse-json": "^2.2.0",
+        "require-from-string": "^1.1.0"
       }
     },
     "create-ecdh": {
@@ -2588,8 +2588,8 @@
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
       "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.0.0"
       }
     },
     "create-error-class": {
@@ -2597,7 +2597,7 @@
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
-        "capture-stack-trace": "1.0.0"
+        "capture-stack-trace": "^1.0.0"
       }
     },
     "create-hash": {
@@ -2605,10 +2605,10 @@
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
       "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "sha.js": "2.4.8"
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "sha.js": "^2.4.0"
       }
     },
     "create-hmac": {
@@ -2616,12 +2616,12 @@
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
       "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.8"
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "create-react-class": {
@@ -2629,9 +2629,9 @@
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.2.tgz",
       "integrity": "sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=",
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       }
     },
     "cross-spawn": {
@@ -2639,9 +2639,9 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cryptiles": {
@@ -2649,7 +2649,7 @@
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       }
     },
     "crypto-browserify": {
@@ -2657,16 +2657,16 @@
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
       "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
       "requires": {
-        "browserify-cipher": "1.0.0",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.0",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "diffie-hellman": "5.0.2",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.14",
-        "public-encrypt": "4.0.0",
-        "randombytes": "2.0.5"
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "crypto-random-string": {
@@ -2684,20 +2684,20 @@
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.4.tgz",
       "integrity": "sha1-bPNXkZLONV6LONX0Ldeh8uyJjQ8=",
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "css-selector-tokenizer": "0.7.0",
-        "cssnano": "3.10.0",
-        "icss-utils": "2.1.0",
-        "loader-utils": "1.1.0",
-        "lodash.camelcase": "4.3.0",
-        "object-assign": "4.1.1",
-        "postcss": "5.2.17",
-        "postcss-modules-extract-imports": "1.1.0",
-        "postcss-modules-local-by-default": "1.2.0",
-        "postcss-modules-scope": "1.1.0",
-        "postcss-modules-values": "1.3.0",
-        "postcss-value-parser": "3.3.0",
-        "source-list-map": "0.1.8"
+        "babel-code-frame": "^6.11.0",
+        "css-selector-tokenizer": "^0.7.0",
+        "cssnano": ">=2.6.1 <4",
+        "icss-utils": "^2.1.0",
+        "loader-utils": "^1.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "object-assign": "^4.0.1",
+        "postcss": "^5.0.6",
+        "postcss-modules-extract-imports": "^1.0.0",
+        "postcss-modules-local-by-default": "^1.0.1",
+        "postcss-modules-scope": "^1.0.0",
+        "postcss-modules-values": "^1.1.0",
+        "postcss-value-parser": "^3.3.0",
+        "source-list-map": "^0.1.7"
       },
       "dependencies": {
         "has-flag": {
@@ -2710,10 +2710,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -2721,7 +2721,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -2731,10 +2731,10 @@
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
       "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "2.1.0",
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
         "domutils": "1.5.1",
-        "nth-check": "1.0.1"
+        "nth-check": "~1.0.1"
       }
     },
     "css-selector-tokenizer": {
@@ -2742,9 +2742,9 @@
       "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
       "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
       "requires": {
-        "cssesc": "0.1.0",
-        "fastparse": "1.1.1",
-        "regexpu-core": "1.0.0"
+        "cssesc": "^0.1.0",
+        "fastparse": "^1.1.1",
+        "regexpu-core": "^1.0.0"
       },
       "dependencies": {
         "regexpu-core": {
@@ -2752,9 +2752,9 @@
           "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
           "requires": {
-            "regenerate": "1.3.3",
-            "regjsgen": "0.2.0",
-            "regjsparser": "0.1.5"
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
           }
         }
       }
@@ -2774,38 +2774,38 @@
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
       "requires": {
-        "autoprefixer": "6.7.7",
-        "decamelize": "1.2.0",
-        "defined": "1.0.0",
-        "has": "1.0.1",
-        "object-assign": "4.1.1",
-        "postcss": "5.2.17",
-        "postcss-calc": "5.3.1",
-        "postcss-colormin": "2.2.2",
-        "postcss-convert-values": "2.6.1",
-        "postcss-discard-comments": "2.0.4",
-        "postcss-discard-duplicates": "2.1.0",
-        "postcss-discard-empty": "2.1.0",
-        "postcss-discard-overridden": "0.1.1",
-        "postcss-discard-unused": "2.2.3",
-        "postcss-filter-plugins": "2.0.2",
-        "postcss-merge-idents": "2.1.7",
-        "postcss-merge-longhand": "2.0.2",
-        "postcss-merge-rules": "2.1.2",
-        "postcss-minify-font-values": "1.0.5",
-        "postcss-minify-gradients": "1.0.5",
-        "postcss-minify-params": "1.2.2",
-        "postcss-minify-selectors": "2.1.1",
-        "postcss-normalize-charset": "1.1.1",
-        "postcss-normalize-url": "3.0.8",
-        "postcss-ordered-values": "2.2.3",
-        "postcss-reduce-idents": "2.4.0",
-        "postcss-reduce-initial": "1.0.1",
-        "postcss-reduce-transforms": "1.0.4",
-        "postcss-svgo": "2.1.6",
-        "postcss-unique-selectors": "2.0.2",
-        "postcss-value-parser": "3.3.0",
-        "postcss-zindex": "2.2.0"
+        "autoprefixer": "^6.3.1",
+        "decamelize": "^1.1.2",
+        "defined": "^1.0.0",
+        "has": "^1.0.1",
+        "object-assign": "^4.0.1",
+        "postcss": "^5.0.14",
+        "postcss-calc": "^5.2.0",
+        "postcss-colormin": "^2.1.8",
+        "postcss-convert-values": "^2.3.4",
+        "postcss-discard-comments": "^2.0.4",
+        "postcss-discard-duplicates": "^2.0.1",
+        "postcss-discard-empty": "^2.0.1",
+        "postcss-discard-overridden": "^0.1.1",
+        "postcss-discard-unused": "^2.2.1",
+        "postcss-filter-plugins": "^2.0.0",
+        "postcss-merge-idents": "^2.1.5",
+        "postcss-merge-longhand": "^2.0.1",
+        "postcss-merge-rules": "^2.0.3",
+        "postcss-minify-font-values": "^1.0.2",
+        "postcss-minify-gradients": "^1.0.1",
+        "postcss-minify-params": "^1.0.4",
+        "postcss-minify-selectors": "^2.0.4",
+        "postcss-normalize-charset": "^1.1.0",
+        "postcss-normalize-url": "^3.0.7",
+        "postcss-ordered-values": "^2.1.0",
+        "postcss-reduce-idents": "^2.2.2",
+        "postcss-reduce-initial": "^1.0.0",
+        "postcss-reduce-transforms": "^1.0.3",
+        "postcss-svgo": "^2.1.1",
+        "postcss-unique-selectors": "^2.0.2",
+        "postcss-value-parser": "^3.2.3",
+        "postcss-zindex": "^2.0.1"
       },
       "dependencies": {
         "autoprefixer": {
@@ -2813,12 +2813,12 @@
           "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
           "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
           "requires": {
-            "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000741",
-            "normalize-range": "0.1.2",
-            "num2fraction": "1.2.2",
-            "postcss": "5.2.17",
-            "postcss-value-parser": "3.3.0"
+            "browserslist": "^1.7.6",
+            "caniuse-db": "^1.0.30000634",
+            "normalize-range": "^0.1.2",
+            "num2fraction": "^1.2.2",
+            "postcss": "^5.2.16",
+            "postcss-value-parser": "^3.2.3"
           }
         },
         "browserslist": {
@@ -2826,8 +2826,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000741",
-            "electron-to-chromium": "1.3.24"
+            "caniuse-db": "^1.0.30000639",
+            "electron-to-chromium": "^1.2.7"
           }
         },
         "has-flag": {
@@ -2840,10 +2840,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -2851,7 +2851,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -2861,8 +2861,8 @@
       "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
       "requires": {
-        "clap": "1.2.3",
-        "source-map": "0.5.7"
+        "clap": "^1.0.9",
+        "source-map": "^0.5.3"
       }
     },
     "cssom": {
@@ -2875,7 +2875,7 @@
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
       "requires": {
-        "cssom": "0.3.2"
+        "cssom": "0.3.x"
       }
     },
     "currently-unhandled": {
@@ -2883,7 +2883,7 @@
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "cyclist": {
@@ -2896,7 +2896,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "0.10.30"
+        "es5-ext": "^0.10.9"
       }
     },
     "damerau-levenshtein": {
@@ -2909,7 +2909,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "data-queue": {
@@ -2922,11 +2922,11 @@
       "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-0.4.0.tgz",
       "integrity": "sha512-BQC3f2jSUgVL1DUjt/ZJr9yWzNYyx3ApNh4NhMYFZBap0c+iTKJqyHRlO4bRT+CZG0mqqOUTNXU3qYvTJlN6OA==",
       "requires": {
-        "async": "2.5.0",
-        "interface-datastore": "0.4.2",
-        "left-pad": "1.3.0",
-        "pull-many": "1.0.8",
-        "pull-stream": "3.6.7"
+        "async": "^2.5.0",
+        "interface-datastore": "~0.4.0",
+        "left-pad": "^1.1.3",
+        "pull-many": "^1.0.8",
+        "pull-stream": "^3.6.1"
       }
     },
     "datastore-fs": {
@@ -2934,14 +2934,14 @@
       "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-0.4.2.tgz",
       "integrity": "sha512-mJ511KiZP1zrkEnCvMqvrurW6YSf3QT4P3bdGVftPl+DeaGxC/gdwj8DE9cWsmyD6E1a50jU2Q8IqhaZGNEBbg==",
       "requires": {
-        "async": "2.6.0",
-        "datastore-core": "0.4.0",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "interface-datastore": "0.4.2",
-        "mkdirp": "0.5.1",
-        "pull-stream": "3.6.7",
-        "write-file-atomic": "2.3.0"
+        "async": "^2.6.0",
+        "datastore-core": "~0.4.0",
+        "glob": "^7.1.2",
+        "graceful-fs": "^4.1.11",
+        "interface-datastore": "^0.4.2",
+        "mkdirp": "^0.5.1",
+        "pull-stream": "^3.6.1",
+        "write-file-atomic": "^2.3.0"
       },
       "dependencies": {
         "async": {
@@ -2949,7 +2949,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         }
       }
@@ -2959,12 +2959,12 @@
       "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-0.7.0.tgz",
       "integrity": "sha512-Wgm6kzkXadFOVkzRpu7KfSm6QwxjsgfPRCrcvVQuR4/CsWeREnmyuzu580fLywRmlIQMbcncu6W02W0HyAzjng==",
       "requires": {
-        "datastore-core": "0.4.0",
-        "interface-datastore": "0.4.2",
-        "level-js": "2.2.4",
-        "leveldown": "1.9.0",
-        "levelup": "1.3.9",
-        "pull-stream": "3.6.7"
+        "datastore-core": "~0.4.0",
+        "interface-datastore": "~0.4.1",
+        "level-js": "^2.2.4",
+        "leveldown": "^1.9.0",
+        "levelup": "^1.3.9",
+        "pull-stream": "^3.6.1"
       },
       "dependencies": {
         "level-js": {
@@ -2972,12 +2972,12 @@
           "resolved": "https://registry.npmjs.org/level-js/-/level-js-2.2.4.tgz",
           "integrity": "sha1-vAVfQYBjXUSJtWHJSG+jcOjBFpc=",
           "requires": {
-            "abstract-leveldown": "0.12.4",
-            "idb-wrapper": "1.7.2",
-            "isbuffer": "0.0.0",
-            "ltgt": "2.2.1",
-            "typedarray-to-buffer": "1.0.4",
-            "xtend": "2.1.2"
+            "abstract-leveldown": "~0.12.0",
+            "idb-wrapper": "^1.5.0",
+            "isbuffer": "~0.0.0",
+            "ltgt": "^2.1.2",
+            "typedarray-to-buffer": "~1.0.0",
+            "xtend": "~2.1.2"
           }
         },
         "object-keys": {
@@ -2990,7 +2990,7 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "requires": {
-            "object-keys": "0.4.0"
+            "object-keys": "~0.4.0"
           }
         }
       }
@@ -3018,7 +3018,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
-        "mimic-response": "1.0.0"
+        "mimic-response": "^1.0.0"
       }
     },
     "deep-equal": {
@@ -3046,7 +3046,7 @@
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
       "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
       "requires": {
-        "strip-bom": "2.0.0"
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -3054,7 +3054,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -3064,7 +3064,7 @@
       "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
       "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
       "requires": {
-        "abstract-leveldown": "2.6.3"
+        "abstract-leveldown": "~2.6.0"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -3072,7 +3072,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
           "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
           "requires": {
-            "xtend": "4.0.1"
+            "xtend": "~4.0.0"
           }
         }
       }
@@ -3082,8 +3082,8 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "foreach": "^2.0.5",
+        "object-keys": "^1.0.8"
       }
     },
     "defined": {
@@ -3096,13 +3096,13 @@
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.2.8"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       },
       "dependencies": {
         "pify": {
@@ -3137,8 +3137,8 @@
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "destroy": {
@@ -3151,7 +3151,7 @@
       "resolved": "https://registry.npmjs.org/detab/-/detab-2.0.1.tgz",
       "integrity": "sha512-/hhdqdQc5thGrqzjyO/pz76lDZ5GSuAs6goxOaKTsvPk7HNnzAyFN5lyHgqpX4/s1i66K8qMGj+VhA9504x7DQ==",
       "requires": {
-        "repeat-string": "1.6.1"
+        "repeat-string": "^1.5.4"
       }
     },
     "detect-indent": {
@@ -3159,7 +3159,7 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "detect-libc": {
@@ -3177,8 +3177,8 @@
       "resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.3.tgz",
       "integrity": "sha1-pNLwYddXoDTs83xRQmCph1DysTE=",
       "requires": {
-        "address": "1.0.2",
-        "debug": "2.6.9"
+        "address": "^1.0.1",
+        "debug": "^2.6.0"
       },
       "dependencies": {
         "debug": {
@@ -3196,7 +3196,7 @@
       "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
       "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
       "requires": {
-        "readable-stream": "1.1.14",
+        "readable-stream": "1.1.x",
         "streamsearch": "0.1.2"
       },
       "dependencies": {
@@ -3210,10 +3210,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -3233,9 +3233,9 @@
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
       "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.0.5"
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
       }
     },
     "dirty-chai": {
@@ -3259,8 +3259,8 @@
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.2.2.tgz",
       "integrity": "sha512-kN+DjfGF7dJGUL7nWRktL9Z18t1rWP3aQlyZdY8XlpvU3Nc6GeFTQApftcjtWKxAZfiggZSGrCEoszNgvnpwDg==",
       "requires": {
-        "ip": "1.1.5",
-        "safe-buffer": "5.1.1"
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "dns-txt": {
@@ -3268,7 +3268,7 @@
       "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "requires": {
-        "buffer-indexof": "1.1.1"
+        "buffer-indexof": "^1.0.0"
       },
       "dependencies": {
         "buffer-indexof": {
@@ -3283,8 +3283,8 @@
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
       }
     },
     "dom-converter": {
@@ -3292,7 +3292,7 @@
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
       "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
       "requires": {
-        "utila": "0.3.3"
+        "utila": "~0.3"
       },
       "dependencies": {
         "utila": {
@@ -3307,8 +3307,8 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -3323,7 +3323,7 @@
       "resolved": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
       "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
       "requires": {
-        "urijs": "1.19.0"
+        "urijs": "^1.16.1"
       }
     },
     "domain-browser": {
@@ -3342,7 +3342,7 @@
       "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -3350,8 +3350,8 @@
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "dot-prop": {
@@ -3359,7 +3359,7 @@
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "requires": {
-        "is-obj": "1.0.1"
+        "is-obj": "^1.0.0"
       }
     },
     "dotenv": {
@@ -3372,9 +3372,9 @@
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
       "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
       "requires": {
-        "browserify-aes": "1.0.8",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6"
+        "browserify-aes": "^1.0.6",
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4"
       }
     },
     "duplexer": {
@@ -3387,7 +3387,7 @@
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "^2.0.2"
       }
     },
     "duplexer3": {
@@ -3400,10 +3400,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
       "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
       "requires": {
-        "end-of-stream": "1.4.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -3412,7 +3412,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.0"
+        "jsbn": "~0.1.0"
       }
     },
     "ecurve": {
@@ -3420,8 +3420,8 @@
       "resolved": "https://registry.npmjs.org/ecurve/-/ecurve-1.0.6.tgz",
       "integrity": "sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==",
       "requires": {
-        "bigi": "1.4.2",
-        "safe-buffer": "5.1.1"
+        "bigi": "^1.1.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "ee-first": {
@@ -3439,13 +3439,13 @@
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.3",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
       }
     },
     "emoji-regex": {
@@ -3468,7 +3468,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
       "requires": {
-        "iconv-lite": "0.4.19"
+        "iconv-lite": "~0.4.13"
       }
     },
     "end-of-stream": {
@@ -3476,7 +3476,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
       "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.4.0"
       }
     },
     "engine.io": {
@@ -3484,12 +3484,12 @@
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
       "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.4",
         "base64id": "1.0.0",
         "cookie": "0.3.1",
-        "debug": "3.1.0",
-        "engine.io-parser": "2.1.2",
-        "ws": "3.3.3"
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.0",
+        "ws": "~3.3.1"
       }
     },
     "engine.io-client": {
@@ -3499,14 +3499,14 @@
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
-        "debug": "3.1.0",
-        "engine.io-parser": "2.1.2",
+        "debug": "~3.1.0",
+        "engine.io-parser": "~2.1.1",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "ws": "3.3.3",
-        "xmlhttprequest-ssl": "1.5.5",
+        "ws": "~3.3.1",
+        "xmlhttprequest-ssl": "~1.5.4",
         "yeast": "0.1.2"
       }
     },
@@ -3516,10 +3516,10 @@
       "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
       "requires": {
         "after": "0.8.2",
-        "arraybuffer.slice": "0.0.7",
+        "arraybuffer.slice": "~0.0.7",
         "base64-arraybuffer": "0.1.5",
         "blob": "0.0.4",
-        "has-binary2": "1.0.2"
+        "has-binary2": "~1.0.2"
       }
     },
     "enhanced-resolve": {
@@ -3527,10 +3527,10 @@
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
       "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "object-assign": "4.1.1",
-        "tapable": "0.2.8"
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.4.0",
+        "object-assign": "^4.0.1",
+        "tapable": "^0.2.7"
       }
     },
     "entities": {
@@ -3544,16 +3544,16 @@
       "integrity": "sha1-lM42QlTcZUxOYZsl7sxkS/ZIHec=",
       "dev": true,
       "requires": {
-        "cheerio": "1.0.0-rc.2",
-        "function.prototype.name": "1.0.3",
-        "is-subset": "0.1.1",
-        "lodash": "4.17.4",
-        "object-is": "1.0.1",
-        "object.assign": "4.0.4",
-        "object.entries": "1.0.4",
-        "object.values": "1.0.4",
-        "raf": "3.3.2",
-        "rst-selector-parser": "2.2.1"
+        "cheerio": "^1.0.0-rc.2",
+        "function.prototype.name": "^1.0.3",
+        "is-subset": "^0.1.1",
+        "lodash": "^4.17.4",
+        "object-is": "^1.0.1",
+        "object.assign": "^4.0.4",
+        "object.entries": "^1.0.4",
+        "object.values": "^1.0.4",
+        "raf": "^3.3.2",
+        "rst-selector-parser": "^2.2.1"
       }
     },
     "enzyme-adapter-react-15": {
@@ -3562,11 +3562,11 @@
       "integrity": "sha1-waPllmvxxyIcQKoPh3hQF1A1QG8=",
       "dev": true,
       "requires": {
-        "enzyme-adapter-utils": "1.0.1",
-        "lodash": "4.17.4",
-        "object.assign": "4.0.4",
-        "object.values": "1.0.4",
-        "prop-types": "15.6.0"
+        "enzyme-adapter-utils": "^1.0.0",
+        "lodash": "^4.17.4",
+        "object.assign": "^4.0.4",
+        "object.values": "^1.0.4",
+        "prop-types": "^15.5.10"
       }
     },
     "enzyme-adapter-utils": {
@@ -3575,9 +3575,9 @@
       "integrity": "sha1-/NgSIzOaVaMS91UmQeBFxAQIQAk=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4",
-        "object.assign": "4.0.4",
-        "prop-types": "15.6.0"
+        "lodash": "^4.17.4",
+        "object.assign": "^4.0.4",
+        "prop-types": "^15.5.10"
       }
     },
     "enzyme-to-json": {
@@ -3586,7 +3586,7 @@
       "integrity": "sha512-L75cYAmiaeb3lleLg9bc0iDtDgMRPsdyJkh69SquE+JS2cw7rURN77VXV2sue9AOzQ3HszWvr7AJyWV3PYZdtA==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.17.4"
       }
     },
     "epimetheus": {
@@ -3594,7 +3594,7 @@
       "resolved": "https://registry.npmjs.org/epimetheus/-/epimetheus-1.0.55.tgz",
       "integrity": "sha1-j0dAiy1oCxIm/9IF1QH499XikgY=",
       "requires": {
-        "prom-client": "10.2.3"
+        "prom-client": "^10.0.0"
       }
     },
     "errno": {
@@ -3602,7 +3602,7 @@
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
       "requires": {
-        "prr": "0.0.0"
+        "prr": "~0.0.0"
       },
       "dependencies": {
         "prr": {
@@ -3617,7 +3617,7 @@
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -3625,11 +3625,11 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.2.tgz",
       "integrity": "sha512-dvhwFL3yjQxNNsOWx6exMlaDrRHCRGMQlnx5lsXDCZ/J7G/frgIIl94zhZSp/galVAYp7VzPi1OrAHta89/yGQ==",
       "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
+        "es-to-primitive": "^1.1.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.1",
+        "is-callable": "^1.1.3",
+        "is-regex": "^1.0.4"
       }
     },
     "es-to-primitive": {
@@ -3637,9 +3637,9 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
+        "is-callable": "^1.1.1",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.1"
       }
     },
     "es5-ext": {
@@ -3647,8 +3647,8 @@
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.30.tgz",
       "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
       "requires": {
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
+        "es6-iterator": "2",
+        "es6-symbol": "~3.1"
       }
     },
     "es6-iterator": {
@@ -3656,9 +3656,9 @@
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-symbol": "^3.1"
       }
     },
     "es6-map": {
@@ -3666,12 +3666,12 @@
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-promise": {
@@ -3684,11 +3684,11 @@
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-symbol": {
@@ -3696,8 +3696,8 @@
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.30"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "es6-weak-map": {
@@ -3705,10 +3705,10 @@
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-html": {
@@ -3726,11 +3726,11 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
       "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.5.7"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.5.6"
       },
       "dependencies": {
         "esprima": {
@@ -3745,10 +3745,10 @@
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint": {
@@ -3756,42 +3756,42 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.4.1.tgz",
       "integrity": "sha1-mc1+r8/8ov+Zpcj18qR01jZLS9M=",
       "requires": {
-        "ajv": "5.2.3",
-        "babel-code-frame": "6.26.0",
-        "chalk": "1.1.3",
-        "concat-stream": "1.6.0",
-        "cross-spawn": "5.1.0",
-        "debug": "2.6.9",
-        "doctrine": "2.0.0",
-        "eslint-scope": "3.7.1",
-        "espree": "3.5.1",
-        "esquery": "1.0.0",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "9.18.0",
-        "ignore": "3.3.5",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "4.0.0",
-        "progress": "2.0.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.4.1",
-        "strip-json-comments": "2.0.1",
-        "table": "4.0.2",
-        "text-table": "0.2.0"
+        "ajv": "^5.2.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^1.1.3",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^2.6.8",
+        "doctrine": "^2.0.0",
+        "eslint-scope": "^3.7.1",
+        "espree": "^3.5.0",
+        "esquery": "^1.0.0",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^9.17.0",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^4.0.0",
+        "progress": "^2.0.0",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "^4.0.1",
+        "text-table": "~0.2.0"
       },
       "dependencies": {
         "debug": {
@@ -3812,8 +3812,8 @@
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
           "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         }
       }
@@ -3828,8 +3828,8 @@
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
       "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
       "requires": {
-        "debug": "2.6.9",
-        "resolve": "1.4.0"
+        "debug": "^2.6.8",
+        "resolve": "^1.2.0"
       },
       "dependencies": {
         "debug": {
@@ -3847,11 +3847,11 @@
       "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-1.9.0.tgz",
       "integrity": "sha512-40aN976qSNPyb9ejTqjEthZITpls1SVKtwguahmH1dzGCwQU/vySE+xX33VZmD8csU0ahVNCtFlsPgKqRBiqgg==",
       "requires": {
-        "loader-fs-cache": "1.0.1",
-        "loader-utils": "1.1.0",
-        "object-assign": "4.1.1",
-        "object-hash": "1.1.8",
-        "rimraf": "2.6.2"
+        "loader-fs-cache": "^1.0.0",
+        "loader-utils": "^1.0.2",
+        "object-assign": "^4.0.1",
+        "object-hash": "^1.1.4",
+        "rimraf": "^2.6.1"
       },
       "dependencies": {
         "rimraf": {
@@ -3859,7 +3859,7 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         }
       }
@@ -3869,8 +3869,8 @@
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
       "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
       "requires": {
-        "debug": "2.6.9",
-        "pkg-dir": "1.0.0"
+        "debug": "^2.6.8",
+        "pkg-dir": "^1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -3886,8 +3886,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-exists": {
@@ -3895,7 +3895,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pkg-dir": {
@@ -3903,7 +3903,7 @@
           "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           }
         }
       }
@@ -3913,7 +3913,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.35.0.tgz",
       "integrity": "sha512-zjXGjOsHds8b84C0Ad3VViKh+sUA9PeXKHwPRlSLwwSX0v1iUJf/6IX7wxc+w2T2tnDH8PT6B/YgtcEuNI3ssA==",
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.15.0"
       }
     },
     "eslint-plugin-import": {
@@ -3921,16 +3921,16 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
       "integrity": "sha512-HGYmpU9f/zJaQiKNQOVfHUh2oLWW3STBrCgH0sHTX1xtsxYlH1zjLh8FlQGEIdZSdTbUMaV36WaZ6ImXkenGxQ==",
       "requires": {
-        "builtin-modules": "1.1.1",
-        "contains-path": "0.1.0",
-        "debug": "2.6.9",
+        "builtin-modules": "^1.1.1",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.8",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.3.1",
-        "eslint-module-utils": "2.1.1",
-        "has": "1.0.1",
-        "lodash.cond": "4.5.2",
-        "minimatch": "3.0.4",
-        "read-pkg-up": "2.0.0"
+        "eslint-import-resolver-node": "^0.3.1",
+        "eslint-module-utils": "^2.1.1",
+        "has": "^1.0.1",
+        "lodash.cond": "^4.3.0",
+        "minimatch": "^3.0.3",
+        "read-pkg-up": "^2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -3946,8 +3946,8 @@
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
         }
       }
@@ -3957,13 +3957,13 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.1.1.tgz",
       "integrity": "sha512-5I9SpoP7gT4wBFOtXT8/tXNPYohHBVfyVfO17vkbC7r9kEIxYJF12D3pKqhk8+xnk12rfxKClS3WCFpVckFTPQ==",
       "requires": {
-        "aria-query": "0.7.0",
-        "array-includes": "3.0.3",
+        "aria-query": "^0.7.0",
+        "array-includes": "^3.0.3",
         "ast-types-flow": "0.0.7",
-        "axobject-query": "0.1.0",
-        "damerau-levenshtein": "1.0.4",
-        "emoji-regex": "6.5.1",
-        "jsx-ast-utils": "1.4.1"
+        "axobject-query": "^0.1.0",
+        "damerau-levenshtein": "^1.0.0",
+        "emoji-regex": "^6.1.0",
+        "jsx-ast-utils": "^1.4.0"
       }
     },
     "eslint-plugin-react": {
@@ -3971,9 +3971,9 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.1.0.tgz",
       "integrity": "sha1-J3cKzzn1/UnNCvQIPOWBBOs5DUw=",
       "requires": {
-        "doctrine": "2.0.0",
-        "has": "1.0.1",
-        "jsx-ast-utils": "1.4.1"
+        "doctrine": "^2.0.0",
+        "has": "^1.0.1",
+        "jsx-ast-utils": "^1.4.1"
       }
     },
     "eslint-scope": {
@@ -3981,8 +3981,8 @@
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
       "requires": {
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "espree": {
@@ -3990,8 +3990,8 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
       "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
       "requires": {
-        "acorn": "5.1.2",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.1.1",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -4004,7 +4004,7 @@
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -4012,8 +4012,8 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
+        "estraverse": "^4.1.0",
+        "object-assign": "^4.0.1"
       }
     },
     "estraverse": {
@@ -4036,8 +4036,8 @@
       "resolved": "https://registry.npmjs.org/eth-hash-to-cid/-/eth-hash-to-cid-0.1.1.tgz",
       "integrity": "sha512-qRmanZnp+YqLGpZaaBX49jEBVpUhYvosNBA/6lrgDDdVhzGCeMbpFycJYyR3prgrxMRPDoMk1H7iMeKRVZKLPA==",
       "requires": {
-        "cids": "0.5.3",
-        "multihashes": "0.4.13"
+        "cids": "^0.5.3",
+        "multihashes": "^0.4.13"
       }
     },
     "ethereum-common": {
@@ -4050,8 +4050,8 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.4.tgz",
       "integrity": "sha1-+MMCMby3B/RRTYoFLB+doQNiTUc=",
       "requires": {
-        "ethereumjs-util": "4.5.0",
-        "rlp": "2.0.0"
+        "ethereumjs-util": "^4.0.1",
+        "rlp": "^2.0.0"
       }
     },
     "ethereumjs-block": {
@@ -4059,11 +4059,11 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
       "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
       "requires": {
-        "async": "2.5.0",
+        "async": "^2.0.1",
         "ethereum-common": "0.2.0",
-        "ethereumjs-tx": "1.3.4",
-        "ethereumjs-util": "5.2.0",
-        "merkle-patricia-tree": "2.3.1"
+        "ethereumjs-tx": "^1.2.2",
+        "ethereumjs-util": "^5.0.0",
+        "merkle-patricia-tree": "^2.1.2"
       },
       "dependencies": {
         "ethereumjs-util": {
@@ -4071,13 +4071,13 @@
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
           "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
           "requires": {
-            "bn.js": "4.11.8",
-            "create-hash": "1.1.3",
-            "ethjs-util": "0.1.4",
-            "keccak": "1.4.0",
-            "rlp": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "secp256k1": "3.5.0"
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
           }
         }
       }
@@ -4087,8 +4087,8 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.4.tgz",
       "integrity": "sha512-kOgUd5jC+0tgV7t52UDECMMz9Uf+Lro+6fSpCvzWemtXfMEcwI3EOxf5mVPMRbTFkMMhuERokNNVF3jItAjidg==",
       "requires": {
-        "ethereum-common": "0.0.18",
-        "ethereumjs-util": "5.2.0"
+        "ethereum-common": "^0.0.18",
+        "ethereumjs-util": "^5.0.0"
       },
       "dependencies": {
         "ethereum-common": {
@@ -4101,13 +4101,13 @@
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
           "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
           "requires": {
-            "bn.js": "4.11.8",
-            "create-hash": "1.1.3",
-            "ethjs-util": "0.1.4",
-            "keccak": "1.4.0",
-            "rlp": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "secp256k1": "3.5.0"
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
           }
         }
       }
@@ -4117,11 +4117,11 @@
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
       "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
       "requires": {
-        "bn.js": "4.11.8",
-        "create-hash": "1.1.3",
-        "keccakjs": "0.2.1",
-        "rlp": "2.0.0",
-        "secp256k1": "3.5.0"
+        "bn.js": "^4.8.0",
+        "create-hash": "^1.1.2",
+        "keccakjs": "^0.2.0",
+        "rlp": "^2.0.0",
+        "secp256k1": "^3.0.1"
       }
     },
     "ethjs-util": {
@@ -4138,8 +4138,8 @@
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.30"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "eventemitter3": {
@@ -4157,7 +4157,7 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
       "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
       "requires": {
-        "original": "1.0.0"
+        "original": ">=0.0.5"
       }
     },
     "evp_bytestokey": {
@@ -4165,8 +4165,8 @@
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.1"
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
       }
     },
     "exec-sh": {
@@ -4174,7 +4174,7 @@
       "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
       "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
       "requires": {
-        "merge": "1.2.0"
+        "merge": "^1.1.3"
       }
     },
     "execa": {
@@ -4182,13 +4182,13 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "expand-brackets": {
@@ -4196,7 +4196,7 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -4204,7 +4204,7 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "expand-template": {
@@ -4217,7 +4217,7 @@
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "requires": {
-        "homedir-polyfill": "1.0.1"
+        "homedir-polyfill": "^1.0.1"
       }
     },
     "express": {
@@ -4225,36 +4225,36 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.1.tgz",
       "integrity": "sha512-STB7LZ4N0L+81FJHGla2oboUHTk4PaN1RsOkoRh9OSeEKylvF5hwKYVX1xCLFaCT7MD0BNG/gX2WFMLqY6EMBw==",
       "requires": {
-        "accepts": "1.3.4",
+        "accepts": "~1.3.4",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.1",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.0",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.2",
+        "proxy-addr": "~2.0.2",
         "qs": "6.5.1",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.1",
         "serve-static": "1.13.1",
         "setprototypeof": "1.1.0",
-        "statuses": "1.3.1",
-        "type-is": "1.6.15",
+        "statuses": "~1.3.1",
+        "type-is": "~1.6.15",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "accepts": {
@@ -4262,7 +4262,7 @@
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
           "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
           "requires": {
-            "mime-types": "2.1.17",
+            "mime-types": "~2.1.16",
             "negotiator": "0.6.1"
           }
         },
@@ -4296,9 +4296,9 @@
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.5.tgz",
       "integrity": "sha512-Msjo64WT5W+NhOpQXh0nOHm+n0RfU1QUwDnKYvJ8dEJ8zlwLrqXNTv5mSUTJpepf41PDJGyhueTw2vNZW+Fr/w==",
       "requires": {
-        "iconv-lite": "0.4.19",
-        "jschardet": "1.5.1",
-        "tmp": "0.0.33"
+        "iconv-lite": "^0.4.17",
+        "jschardet": "^1.4.2",
+        "tmp": "^0.0.33"
       }
     },
     "extglob": {
@@ -4306,7 +4306,7 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "extract-text-webpack-plugin": {
@@ -4314,10 +4314,10 @@
       "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.0.tgz",
       "integrity": "sha1-kMqnkHvESfM1AF46x1MrQbAN5hI=",
       "requires": {
-        "async": "2.5.0",
-        "loader-utils": "1.1.0",
-        "schema-utils": "0.3.0",
-        "webpack-sources": "1.0.1"
+        "async": "^2.4.1",
+        "loader-utils": "^1.1.0",
+        "schema-utils": "^0.3.0",
+        "webpack-sources": "^1.0.1"
       }
     },
     "extsprintf": {
@@ -4355,7 +4355,7 @@
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
       "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
       "requires": {
-        "websocket-driver": "0.7.0"
+        "websocket-driver": ">=0.5.1"
       }
     },
     "fb-watchman": {
@@ -4363,7 +4363,7 @@
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "requires": {
-        "bser": "2.0.0"
+        "bser": "^2.0.0"
       }
     },
     "fbjs": {
@@ -4371,13 +4371,13 @@
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
       "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
       "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "promise": "7.3.1",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.14"
+        "core-js": "^1.0.0",
+        "isomorphic-fetch": "^2.1.1",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^0.7.9"
       },
       "dependencies": {
         "core-js": {
@@ -4390,7 +4390,7 @@
           "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
           "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
           "requires": {
-            "asap": "2.0.6"
+            "asap": "~2.0.3"
           }
         }
       }
@@ -4400,7 +4400,7 @@
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -4408,8 +4408,8 @@
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "file-loader": {
@@ -4417,7 +4417,7 @@
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.11.2.tgz",
       "integrity": "sha512-N+uhF3mswIFeziHQjGScJ/yHXYt3DiLBeC+9vWW+WjUBiClMSOlV1YrXQi+7KM2aA3Rn4Bybgv+uXFQbfkzpvg==",
       "requires": {
-        "loader-utils": "1.1.0"
+        "loader-utils": "^1.0.2"
       }
     },
     "file-type": {
@@ -4435,8 +4435,8 @@
       "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
       "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
       "requires": {
-        "glob": "7.1.2",
-        "minimatch": "3.0.4"
+        "glob": "^7.0.3",
+        "minimatch": "^3.0.3"
       }
     },
     "filesize": {
@@ -4449,11 +4449,11 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "filled-array": {
@@ -4467,12 +4467,12 @@
       "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -4490,9 +4490,9 @@
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
       "requires": {
-        "commondir": "1.0.1",
-        "make-dir": "1.0.0",
-        "pkg-dir": "2.0.0"
+        "commondir": "^1.0.1",
+        "make-dir": "^1.0.0",
+        "pkg-dir": "^2.0.0"
       }
     },
     "find-process": {
@@ -4500,9 +4500,9 @@
       "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.1.1.tgz",
       "integrity": "sha1-V/sa28f0MEeG23IKSf69cIoxYtQ=",
       "requires": {
-        "chalk": "2.4.1",
-        "commander": "2.11.0",
-        "debug": "2.6.9"
+        "chalk": "^2.0.1",
+        "commander": "^2.11.0",
+        "debug": "^2.6.8"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4510,7 +4510,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -4518,9 +4518,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "debug": {
@@ -4541,7 +4541,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -4551,7 +4551,7 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "flat-cache": {
@@ -4559,10 +4559,10 @@
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "flatmap": {
@@ -4580,8 +4580,8 @@
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
       "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.4"
       }
     },
     "for-in": {
@@ -4594,7 +4594,7 @@
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "foreach": {
@@ -4612,9 +4612,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -4632,8 +4632,8 @@
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
       }
     },
     "fs-constants": {
@@ -4643,9 +4643,10 @@
     },
     "fs-ext": {
       "version": "github:baudehlo/node-fs-ext#500be8514729c194ac7ca2b30b5bc7eaf812670d",
+      "from": "fs-ext@github:baudehlo/node-fs-ext#500be8514729c194ac7ca2b30b5bc7eaf812670d",
       "optional": true,
       "requires": {
-        "nan": "2.7.0"
+        "nan": "^2.0"
       }
     },
     "fs-extra": {
@@ -4653,9 +4654,9 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
       "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "3.0.1",
-        "universalify": "0.1.1"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^3.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs-write-stream-atomic": {
@@ -4663,10 +4664,10 @@
       "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
       "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "iferr": "0.1.5",
-        "imurmurhash": "0.1.4",
-        "readable-stream": "2.3.3"
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
       }
     },
     "fs.realpath": {
@@ -4680,8 +4681,8 @@
       "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
       "optional": true,
       "requires": {
-        "nan": "2.7.0",
-        "node-pre-gyp": "0.6.36"
+        "nan": "^2.3.0",
+        "node-pre-gyp": "^0.6.36"
       },
       "dependencies": {
         "abbrev": {
@@ -4696,8 +4697,8 @@
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "optional": true,
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "ansi-regex": {
@@ -4717,8 +4718,8 @@
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "asn1": {
@@ -4762,7 +4763,7 @@
           "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           }
         },
         "block-stream": {
@@ -4770,7 +4771,7 @@
           "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
           "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "~2.0.0"
           }
         },
         "boom": {
@@ -4778,7 +4779,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "brace-expansion": {
@@ -4786,7 +4787,7 @@
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
           "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
           "requires": {
-            "balanced-match": "0.4.2",
+            "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
           }
         },
@@ -4817,7 +4818,7 @@
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "concat-map": {
@@ -4841,7 +4842,7 @@
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "optional": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "dashdash": {
@@ -4850,7 +4851,7 @@
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -4893,7 +4894,7 @@
           "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "extend": {
@@ -4919,9 +4920,9 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "optional": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "fs.realpath": {
@@ -4934,10 +4935,10 @@
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
           }
         },
         "fstream-ignore": {
@@ -4946,9 +4947,9 @@
           "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
           "optional": true,
           "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
+            "fstream": "^1.0.0",
+            "inherits": "2",
+            "minimatch": "^3.0.0"
           }
         },
         "gauge": {
@@ -4957,14 +4958,14 @@
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "optional": true,
           "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "getpass": {
@@ -4973,7 +4974,7 @@
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -4989,12 +4990,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -5014,8 +5015,8 @@
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "optional": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
           }
         },
         "has-unicode": {
@@ -5030,10 +5031,10 @@
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "optional": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
@@ -5047,9 +5048,9 @@
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "optional": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "inflight": {
@@ -5057,8 +5058,8 @@
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -5077,7 +5078,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-typedarray": {
@@ -5103,7 +5104,7 @@
           "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "jsbn": {
@@ -5124,7 +5125,7 @@
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "optional": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -5169,7 +5170,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
           "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
           "requires": {
-            "mime-db": "1.27.0"
+            "mime-db": "~1.27.0"
           }
         },
         "minimatch": {
@@ -5177,7 +5178,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -5205,15 +5206,15 @@
           "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
           "optional": true,
           "requires": {
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
+            "mkdirp": "^0.5.1",
+            "nopt": "^4.0.1",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "request": "^2.81.0",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^2.2.1",
+            "tar-pack": "^3.4.0"
           }
         },
         "nopt": {
@@ -5222,8 +5223,8 @@
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "optional": true,
           "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npmlog": {
@@ -5232,10 +5233,10 @@
           "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -5260,7 +5261,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -5281,8 +5282,8 @@
           "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -5319,10 +5320,10 @@
           "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -5338,13 +5339,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
           "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
           "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
+            "buffer-shims": "~1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
           }
         },
         "request": {
@@ -5353,28 +5354,28 @@
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "optional": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
           }
         },
         "rimraf": {
@@ -5382,7 +5383,7 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
           "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -5414,7 +5415,7 @@
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "optional": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "sshpk": {
@@ -5423,15 +5424,15 @@
           "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
           "optional": true,
           "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jodid25519": "^1.0.0",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -5447,9 +5448,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -5457,7 +5458,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
           "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "stringstream": {
@@ -5471,7 +5472,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -5485,9 +5486,9 @@
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
           }
         },
         "tar-pack": {
@@ -5496,14 +5497,14 @@
           "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
           "optional": true,
           "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
+            "debug": "^2.2.0",
+            "fstream": "^1.0.10",
+            "fstream-ignore": "^1.0.5",
+            "once": "^1.3.3",
+            "readable-stream": "^2.1.4",
+            "rimraf": "^2.5.1",
+            "tar": "^2.2.1",
+            "uid-number": "^0.0.6"
           }
         },
         "tough-cookie": {
@@ -5512,7 +5513,7 @@
           "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "optional": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         },
         "tunnel-agent": {
@@ -5521,7 +5522,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "optional": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -5562,7 +5563,7 @@
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -5577,7 +5578,7 @@
       "resolved": "https://registry.npmjs.org/fsm/-/fsm-1.0.2.tgz",
       "integrity": "sha1-4uubKXR+gGu7kPjVRT4vnXvSN4M=",
       "requires": {
-        "split": "0.3.3"
+        "split": "~0.3.0"
       }
     },
     "fsm-event": {
@@ -5585,7 +5586,7 @@
       "resolved": "https://registry.npmjs.org/fsm-event/-/fsm-event-2.1.0.tgz",
       "integrity": "sha1-04VxbtOPnJL+qyumAeKqxsC6WpI=",
       "requires": {
-        "fsm": "1.0.2"
+        "fsm": "^1.0.2"
       }
     },
     "function-bind": {
@@ -5599,9 +5600,9 @@
       "integrity": "sha512-5EblxZUdioXi2JiMZ9FUbwYj40eQ9MFHyzFLBSPdlRl3SO8l7SLWuAnQ/at/1Wi4hjJwME/C5WpF2ZfAc8nGNw==",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.1",
-        "is-callable": "1.1.3"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.0",
+        "is-callable": "^1.1.3"
       }
     },
     "functional-red-black-tree": {
@@ -5619,14 +5620,14 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "gc-stats": {
@@ -5635,8 +5636,8 @@
       "integrity": "sha512-B3H6EnfqxhI940ebenWHJI9p40is8yEDlyv3qKgZYmQmiHA5DvCcF7rgZAoiWPiOAdA/iVVguWV4Z7ACCH3JdA==",
       "optional": true,
       "requires": {
-        "nan": "2.7.0",
-        "node-pre-gyp": "0.7.0"
+        "nan": "^2.6.2",
+        "node-pre-gyp": "^0.7.0"
       },
       "dependencies": {
         "abbrev": {
@@ -5658,8 +5659,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.1"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "asn1": {
@@ -5686,21 +5687,21 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           }
         },
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "~2.0.0"
           }
         },
         "brace-expansion": {
           "version": "1.1.8",
           "bundled": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -5723,7 +5724,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "concat-map": {
@@ -5743,7 +5744,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -5785,7 +5786,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "extend": {
@@ -5820,10 +5821,10 @@
           "version": "1.0.11",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
           }
         },
         "fstream-ignore": {
@@ -5831,9 +5832,9 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
+            "fstream": "^1.0.0",
+            "inherits": "2",
+            "minimatch": "^3.0.0"
           }
         },
         "gauge": {
@@ -5841,14 +5842,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "aproba": "1.1.2",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "getpass": {
@@ -5856,7 +5857,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -5870,12 +5871,12 @@
           "version": "7.1.2",
           "bundled": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -5891,8 +5892,8 @@
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -5908,7 +5909,7 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-typedarray": {
@@ -5967,7 +5968,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -5991,16 +5992,16 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.6",
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "nopt": "^4.0.1",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
             "request": "2.83.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.1"
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^2.2.1",
+            "tar-pack": "^3.4.0"
           },
           "dependencies": {
             "ajv": {
@@ -6008,10 +6009,10 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
               }
             },
             "assert-plus": {
@@ -6029,7 +6030,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "hoek": "4.2.1"
+                "hoek": "4.x.x"
               }
             },
             "cryptiles": {
@@ -6037,7 +6038,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "boom": "5.2.0"
+                "boom": "5.x.x"
               },
               "dependencies": {
                 "boom": {
@@ -6045,7 +6046,7 @@
                   "bundled": true,
                   "optional": true,
                   "requires": {
-                    "hoek": "4.2.1"
+                    "hoek": "4.x.x"
                   }
                 }
               }
@@ -6055,9 +6056,9 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "asynckit": "0.4.0",
+                "asynckit": "^0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
+                "mime-types": "^2.1.12"
               },
               "dependencies": {
                 "combined-stream": {
@@ -6065,7 +6066,7 @@
                   "bundled": true,
                   "optional": true,
                   "requires": {
-                    "delayed-stream": "1.0.0"
+                    "delayed-stream": "~1.0.0"
                   }
                 }
               }
@@ -6080,8 +6081,8 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
+                "ajv": "^5.1.0",
+                "har-schema": "^2.0.0"
               }
             },
             "hawk": {
@@ -6089,10 +6090,10 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "boom": "4.3.1",
-                "cryptiles": "3.1.2",
-                "hoek": "4.2.1",
-                "sntp": "2.1.0"
+                "boom": "4.x.x",
+                "cryptiles": "3.x.x",
+                "hoek": "4.x.x",
+                "sntp": "2.x.x"
               }
             },
             "hoek": {
@@ -6104,9 +6105,9 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.0",
-                "sshpk": "1.13.1"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
               }
             },
             "mime-db": {
@@ -6117,7 +6118,7 @@
               "version": "2.1.18",
               "bundled": true,
               "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": "~1.33.0"
               }
             },
             "performance-now": {
@@ -6135,28 +6136,28 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.18",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.6.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.1",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.1",
+                "har-validator": "~5.0.3",
+                "hawk": "~6.0.2",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.17",
+                "oauth-sign": "~0.8.2",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.1",
+                "safe-buffer": "^5.1.1",
+                "stringstream": "~0.0.5",
+                "tough-cookie": "~2.3.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.1.0"
               }
             },
             "sntp": {
@@ -6164,7 +6165,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "hoek": "4.2.1"
+                "hoek": "4.x.x"
               }
             },
             "tough-cookie": {
@@ -6172,7 +6173,7 @@
               "bundled": true,
               "optional": true,
               "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
               }
             }
           }
@@ -6182,8 +6183,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npmlog": {
@@ -6191,10 +6192,10 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -6215,7 +6216,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -6233,8 +6234,8 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -6255,10 +6256,10 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -6272,20 +6273,20 @@
           "version": "2.3.1",
           "bundled": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.2",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.0",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
           }
         },
         "rimraf": {
           "version": "2.6.1",
           "bundled": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -6312,14 +6313,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -6333,16 +6334,16 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "~5.0.1"
           },
           "dependencies": {
             "safe-buffer": {
@@ -6360,7 +6361,7 @@
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -6372,9 +6373,9 @@
           "version": "2.2.1",
           "bundled": true,
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
           }
         },
         "tar-pack": {
@@ -6382,14 +6383,14 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.9",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.3.1",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
+            "debug": "^2.2.0",
+            "fstream": "^1.0.10",
+            "fstream-ignore": "^1.0.5",
+            "once": "^1.3.3",
+            "readable-stream": "^2.1.4",
+            "rimraf": "^2.5.1",
+            "tar": "^2.2.1",
+            "uid-number": "^0.0.6"
           }
         },
         "tunnel-agent": {
@@ -6397,7 +6398,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -6432,7 +6433,7 @@
           "bundled": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -6456,8 +6457,8 @@
       "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-1.0.1.tgz",
       "integrity": "sha1-gC+kIIQ03nEgUYKxWrfxNSCI5YA=",
       "requires": {
-        "async": "1.5.2",
-        "gar": "1.0.3"
+        "async": "^1.4.2",
+        "gar": "^1.0.2"
       },
       "dependencies": {
         "async": {
@@ -6482,7 +6483,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "github-from-package": {
@@ -6495,12 +6496,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -6508,8 +6509,8 @@
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -6517,7 +6518,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "global-dirs": {
@@ -6525,7 +6526,7 @@
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "requires": {
-        "ini": "1.3.4"
+        "ini": "^1.3.4"
       }
     },
     "global-modules": {
@@ -6533,9 +6534,9 @@
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
       "requires": {
-        "global-prefix": "1.0.2",
-        "is-windows": "1.0.1",
-        "resolve-dir": "1.0.1"
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
       }
     },
     "global-prefix": {
@@ -6543,11 +6544,11 @@
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
       "requires": {
-        "expand-tilde": "2.0.2",
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.4",
-        "is-windows": "1.0.1",
-        "which": "1.3.0"
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
       }
     },
     "globals": {
@@ -6560,12 +6561,12 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -6580,17 +6581,17 @@
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "unzip-response": "2.0.1",
-        "url-parse-lax": "1.0.0"
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
       },
       "dependencies": {
         "unzip-response": {
@@ -6615,7 +6616,7 @@
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
       "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
       "requires": {
-        "duplexer": "0.1.1"
+        "duplexer": "^0.1.1"
       }
     },
     "handle-thing": {
@@ -6628,10 +6629,10 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
       "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "async": {
@@ -6651,8 +6652,8 @@
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "optional": true,
           "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
             "wordwrap": "0.0.2"
           }
         },
@@ -6661,7 +6662,7 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "uglify-js": {
@@ -6670,9 +6671,9 @@
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "optional": true,
           "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           },
           "dependencies": {
             "source-map": {
@@ -6695,9 +6696,9 @@
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "optional": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         }
@@ -6708,24 +6709,24 @@
       "resolved": "https://registry.npmjs.org/hapi/-/hapi-16.6.3.tgz",
       "integrity": "sha512-Fe1EtSlRWdez9c1sLDrHZYxpsp3IddwtUWp7y65TCBW5CMcBP98X4WnoBJZTGsDZnk/FDkRyEMhUVsC9qysDPg==",
       "requires": {
-        "accept": "2.1.4",
-        "ammo": "2.0.4",
-        "boom": "5.2.0",
-        "call": "4.0.2",
-        "catbox": "7.1.5",
-        "catbox-memory": "2.0.4",
-        "cryptiles": "3.1.2",
-        "heavy": "4.0.4",
-        "hoek": "4.2.0",
-        "iron": "4.0.5",
-        "items": "2.1.1",
-        "joi": "11.4.0",
-        "mimos": "3.0.3",
-        "podium": "1.3.0",
-        "shot": "3.4.2",
-        "statehood": "5.0.3",
-        "subtext": "5.0.0",
-        "topo": "2.0.2"
+        "accept": "^2.1.4",
+        "ammo": "^2.0.4",
+        "boom": "^5.2.0",
+        "call": "^4.0.2",
+        "catbox": "^7.1.5",
+        "catbox-memory": "^2.0.4",
+        "cryptiles": "^3.1.2",
+        "heavy": "^4.0.4",
+        "hoek": "^4.2.0",
+        "iron": "^4.0.5",
+        "items": "^2.1.1",
+        "joi": "^11.1.0",
+        "mimos": "^3.0.3",
+        "podium": "^1.3.0",
+        "shot": "^3.4.2",
+        "statehood": "^5.0.3",
+        "subtext": "^5.0.0",
+        "topo": "^2.0.2"
       },
       "dependencies": {
         "isemail": {
@@ -6733,7 +6734,7 @@
           "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.2.tgz",
           "integrity": "sha512-zfRhJn9rFSGhzU5tGZqepRSAj3+g6oTOHxMGGriWNJZzyLPUK8H7VHpqKntegnW8KLyGA9zwuNaCoopl40LTpg==",
           "requires": {
-            "punycode": "2.1.0"
+            "punycode": "2.x.x"
           }
         },
         "joi": {
@@ -6741,9 +6742,9 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-11.4.0.tgz",
           "integrity": "sha512-O7Uw+w/zEWgbL6OcHbyACKSj0PkQeUgmehdoXVSxt92QFCq4+1390Rwh5moI2K/OgC7D8RHRZqHZxT2husMJHA==",
           "requires": {
-            "hoek": "4.2.0",
-            "isemail": "3.1.2",
-            "topo": "2.0.2"
+            "hoek": "4.x.x",
+            "isemail": "3.x.x",
+            "topo": "2.x.x"
           }
         }
       }
@@ -6763,8 +6764,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.2.3",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has": {
@@ -6772,7 +6773,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.0.2"
       }
     },
     "has-ansi": {
@@ -6780,7 +6781,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-binary2": {
@@ -6818,7 +6819,7 @@
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "hash.js": {
@@ -6826,8 +6827,8 @@
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "hashlru": {
@@ -6840,11 +6841,11 @@
       "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-1.1.0.tgz",
       "integrity": "sha1-NZzDOdyMzx36ykGRWtY/1UYTCs0=",
       "requires": {
-        "camelcase": "3.0.0",
-        "has": "1.0.1",
-        "hastscript": "3.1.0",
-        "property-information": "3.2.0",
-        "vfile-location": "2.0.2"
+        "camelcase": "^3.0.0",
+        "has": "^1.0.1",
+        "hastscript": "^3.0.0",
+        "property-information": "^3.1.0",
+        "vfile-location": "^2.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -6869,7 +6870,7 @@
       "resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-1.1.2.tgz",
       "integrity": "sha1-0QvWdXoh5ZwTq8iuNTDdO219Z54=",
       "requires": {
-        "xtend": "4.0.1"
+        "xtend": "^4.0.1"
       }
     },
     "hast-util-to-html": {
@@ -6877,17 +6878,17 @@
       "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-3.1.0.tgz",
       "integrity": "sha1-iCyZhJ5AEw6ZHAQuRW1FPZXDbP8=",
       "requires": {
-        "ccount": "1.0.3",
-        "comma-separated-tokens": "1.0.5",
-        "hast-util-is-element": "1.0.0",
-        "hast-util-whitespace": "1.0.0",
-        "html-void-elements": "1.0.3",
-        "kebab-case": "1.0.0",
-        "property-information": "3.2.0",
-        "space-separated-tokens": "1.1.2",
-        "stringify-entities": "1.3.2",
-        "unist-util-is": "2.1.2",
-        "xtend": "4.0.1"
+        "ccount": "^1.0.0",
+        "comma-separated-tokens": "^1.0.1",
+        "hast-util-is-element": "^1.0.0",
+        "hast-util-whitespace": "^1.0.0",
+        "html-void-elements": "^1.0.0",
+        "kebab-case": "^1.0.0",
+        "property-information": "^3.1.0",
+        "space-separated-tokens": "^1.0.0",
+        "stringify-entities": "^1.0.1",
+        "unist-util-is": "^2.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "hast-util-whitespace": {
@@ -6900,11 +6901,11 @@
       "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-3.1.0.tgz",
       "integrity": "sha512-8V34dMSDT1Ik+ZSgTzCLdyp89MrWxcxctXPxhmb72GQj1Xkw1aHPM9UaHCWewvH2Q+PVkYUm4ZJVw4T0dgEGNA==",
       "requires": {
-        "camelcase": "3.0.0",
-        "comma-separated-tokens": "1.0.5",
-        "hast-util-parse-selector": "2.1.0",
-        "property-information": "3.2.0",
-        "space-separated-tokens": "1.1.2"
+        "camelcase": "^3.0.0",
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.0.0",
+        "property-information": "^3.0.0",
+        "space-separated-tokens": "^1.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -6919,10 +6920,10 @@
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.0.2"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       },
       "dependencies": {
         "boom": {
@@ -6930,7 +6931,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
           "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.x.x"
           }
         }
       }
@@ -6950,9 +6951,9 @@
       "resolved": "https://registry.npmjs.org/heavy/-/heavy-4.0.4.tgz",
       "integrity": "sha1-NskTNsAMz+hSyqTRUwhjNc0vAOk=",
       "requires": {
-        "boom": "5.2.0",
-        "hoek": "4.2.0",
-        "joi": "10.6.0"
+        "boom": "5.x.x",
+        "hoek": "4.x.x",
+        "joi": "10.x.x"
       },
       "dependencies": {
         "joi": {
@@ -6960,10 +6961,10 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
           "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
           "requires": {
-            "hoek": "4.2.0",
-            "isemail": "2.2.1",
-            "items": "2.1.1",
-            "topo": "2.0.2"
+            "hoek": "4.x.x",
+            "isemail": "2.x.x",
+            "items": "2.x.x",
+            "topo": "2.x.x"
           }
         }
       }
@@ -6973,11 +6974,11 @@
       "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
       "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
       "requires": {
-        "invariant": "2.2.2",
-        "loose-envify": "1.3.1",
-        "resolve-pathname": "2.2.0",
-        "value-equal": "0.4.0",
-        "warning": "3.0.0"
+        "invariant": "^2.2.1",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^2.2.0",
+        "value-equal": "^0.4.0",
+        "warning": "^3.0.0"
       },
       "dependencies": {
         "invariant": {
@@ -6985,7 +6986,7 @@
           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
           "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "js-tokens": {
@@ -6998,7 +6999,7 @@
           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "resolve-pathname": {
@@ -7016,7 +7017,7 @@
           "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
           "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         }
       }
@@ -7026,9 +7027,9 @@
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
-        "hash.js": "1.1.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "hoek": {
@@ -7041,8 +7042,8 @@
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "homedir-polyfill": {
@@ -7050,7 +7051,7 @@
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
       "requires": {
-        "parse-passwd": "1.0.0"
+        "parse-passwd": "^1.0.0"
       }
     },
     "hosted-git-info": {
@@ -7063,10 +7064,10 @@
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
       "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
       "requires": {
-        "inherits": "2.0.3",
-        "obuf": "1.1.1",
-        "readable-stream": "2.3.3",
-        "wbuf": "1.7.2"
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
       }
     },
     "html-comment-regex": {
@@ -7079,7 +7080,7 @@
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
       "integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
       "requires": {
-        "whatwg-encoding": "1.0.1"
+        "whatwg-encoding": "^1.0.1"
       }
     },
     "html-entities": {
@@ -7092,14 +7093,14 @@
       "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.5.tgz",
       "integrity": "sha512-g+1+NBycQI0fGnggd52JM8TRUweG7+9W2wrtjGitMAqc4G7maweAHvVAAjz9veHseIH3tYKE2lk2USGSoewIrQ==",
       "requires": {
-        "camel-case": "3.0.0",
-        "clean-css": "4.1.9",
-        "commander": "2.11.0",
-        "he": "1.1.1",
-        "ncname": "1.0.0",
-        "param-case": "2.1.1",
-        "relateurl": "0.2.7",
-        "uglify-js": "3.1.3"
+        "camel-case": "3.0.x",
+        "clean-css": "4.1.x",
+        "commander": "2.11.x",
+        "he": "1.1.x",
+        "ncname": "1.0.x",
+        "param-case": "2.1.x",
+        "relateurl": "0.2.x",
+        "uglify-js": "3.1.x"
       }
     },
     "html-void-elements": {
@@ -7112,12 +7113,12 @@
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.29.0.tgz",
       "integrity": "sha1-6Yf0IYU9O2k4yMTIFxhC5f0XryM=",
       "requires": {
-        "bluebird": "3.5.0",
-        "html-minifier": "3.5.5",
-        "loader-utils": "0.2.17",
-        "lodash": "4.17.4",
-        "pretty-error": "2.1.1",
-        "toposort": "1.0.6"
+        "bluebird": "^3.4.7",
+        "html-minifier": "^3.2.3",
+        "loader-utils": "^0.2.16",
+        "lodash": "^4.17.3",
+        "pretty-error": "^2.0.2",
+        "toposort": "^1.0.0"
       },
       "dependencies": {
         "loader-utils": {
@@ -7125,10 +7126,10 @@
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
           "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
           "requires": {
-            "big.js": "3.2.0",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1",
-            "object-assign": "4.1.1"
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
           }
         }
       }
@@ -7139,12 +7140,12 @@
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.4.1",
-        "domutils": "1.5.1",
-        "entities": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "http-deceiver": {
@@ -7160,7 +7161,7 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
+        "statuses": ">= 1.3.1 < 2"
       },
       "dependencies": {
         "setprototypeof": {
@@ -7180,8 +7181,8 @@
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
       "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
       "requires": {
-        "eventemitter3": "1.2.0",
-        "requires-port": "1.0.0"
+        "eventemitter3": "1.x.x",
+        "requires-port": "1.x.x"
       }
     },
     "http-proxy-middleware": {
@@ -7189,10 +7190,10 @@
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
       "integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
       "requires": {
-        "http-proxy": "1.16.2",
-        "is-glob": "3.1.0",
-        "lodash": "4.17.4",
-        "micromatch": "2.3.11"
+        "http-proxy": "^1.16.2",
+        "is-glob": "^3.1.0",
+        "lodash": "^4.17.2",
+        "micromatch": "^2.3.11"
       },
       "dependencies": {
         "is-extglob": {
@@ -7205,7 +7206,7 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         }
       }
@@ -7215,9 +7216,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-browserify": {
@@ -7230,7 +7231,7 @@
       "resolved": "https://registry.npmjs.org/human-to-milliseconds/-/human-to-milliseconds-1.0.0.tgz",
       "integrity": "sha512-Rp1uvdGYHZ8v6GCl3N6QW48MlABqvLCzKbeNPPddbFdDEC7G1G+8oq0hmCiem4PSJIDwLvAxkPi3FF5BDoeKew==",
       "requires": {
-        "promisify-es6": "1.0.3"
+        "promisify-es6": "^1.0.3"
       }
     },
     "hyperdiff": {
@@ -7238,9 +7239,9 @@
       "resolved": "https://registry.npmjs.org/hyperdiff/-/hyperdiff-2.0.4.tgz",
       "integrity": "sha512-rCRkwmjC2+X7YHyki1t/RCYD6NGWc9OGQiLyhSUArPWSfAeeGGBfUTApvfMEfGFov/zaVmssPWk8FN26Cz9yrQ==",
       "requires": {
-        "debug": "3.1.0",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.pullat": "4.6.0"
+        "debug": "~3.1.0",
+        "lodash.clonedeep": "~4.5.0",
+        "lodash.pullat": "~4.6.0"
       }
     },
     "iconv-lite": {
@@ -7258,7 +7259,7 @@
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "requires": {
-        "postcss": "6.0.12"
+        "postcss": "^6.0.1"
       }
     },
     "idb-readable-stream": {
@@ -7266,7 +7267,7 @@
       "resolved": "https://registry.npmjs.org/idb-readable-stream/-/idb-readable-stream-0.0.4.tgz",
       "integrity": "sha1-MoPaZkW/ayINxhumHfYr7l2uSs8=",
       "requires": {
-        "xtend": "4.0.1"
+        "xtend": "^4.0.1"
       }
     },
     "idb-wrapper": {
@@ -7309,7 +7310,7 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "indexes-of": {
@@ -7327,12 +7328,12 @@
       "resolved": "https://registry.npmjs.org/inert/-/inert-4.2.1.tgz",
       "integrity": "sha512-qmbbZYPSzU/eOUOStPQvSjrU9IR1Q3uDtsEsVwnBQeZG43xu7Nrj6yuUrX3ice/03rv5dj/KiKB+NGCbiqH+aQ==",
       "requires": {
-        "ammo": "2.0.4",
-        "boom": "5.2.0",
-        "hoek": "4.2.0",
-        "items": "2.1.1",
-        "joi": "10.6.0",
-        "lru-cache": "4.1.1"
+        "ammo": "2.x.x",
+        "boom": "5.x.x",
+        "hoek": "4.x.x",
+        "items": "2.x.x",
+        "joi": "10.x.x",
+        "lru-cache": "4.1.x"
       },
       "dependencies": {
         "joi": {
@@ -7340,10 +7341,10 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
           "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
           "requires": {
-            "hoek": "4.2.0",
-            "isemail": "2.2.1",
-            "items": "2.1.1",
-            "topo": "2.0.2"
+            "hoek": "4.x.x",
+            "isemail": "2.x.x",
+            "items": "2.x.x",
+            "topo": "2.x.x"
           }
         }
       }
@@ -7353,8 +7354,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -7372,20 +7373,20 @@
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "requires": {
-        "ansi-escapes": "3.0.0",
-        "chalk": "2.1.0",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.0.5",
-        "figures": "2.0.0",
-        "lodash": "4.17.4",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "ansi-regex": {
@@ -7398,9 +7399,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -7413,8 +7414,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -7422,7 +7423,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -7432,8 +7433,8 @@
       "resolved": "https://registry.npmjs.org/interface-connection/-/interface-connection-0.3.2.tgz",
       "integrity": "sha1-5JSYg/bqeft+3QHuP0/KR6Kf0sQ=",
       "requires": {
-        "pull-defer": "0.2.2",
-        "timed-tape": "0.1.1"
+        "pull-defer": "~0.2.2",
+        "timed-tape": "~0.1.1"
       }
     },
     "interface-datastore": {
@@ -7441,10 +7442,10 @@
       "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.4.2.tgz",
       "integrity": "sha512-Vztsb1SXZANtwwGkpDoxOTMELhhuCklkQKbjma6PY4XLwIyrhQ1xEKaG1sOHavMXoghThw8IZEysiCDrofOQKQ==",
       "requires": {
-        "async": "2.6.0",
-        "pull-defer": "0.2.2",
-        "pull-stream": "3.6.7",
-        "uuid": "3.1.0"
+        "async": "^2.6.0",
+        "pull-defer": "^0.2.2",
+        "pull-stream": "^3.6.1",
+        "uuid": "^3.1.0"
       },
       "dependencies": {
         "async": {
@@ -7452,7 +7453,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         }
       }
@@ -7462,7 +7463,7 @@
       "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
       "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
       "requires": {
-        "meow": "3.7.0"
+        "meow": "^3.3.0"
       }
     },
     "interpret": {
@@ -7475,7 +7476,7 @@
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -7494,11 +7495,11 @@
       "integrity": "sha512-7ay355oMN34iXhET1BmCJVsHjOTSItEEIIpOs38qUC23AIhOy+xIPnkrTuEFjeLMrTJ7m8KMXWgWfy/2Vn9sDw==",
       "requires": {
         "jsbn": "1.1.0",
-        "lodash.find": "4.6.0",
-        "lodash.max": "4.0.1",
-        "lodash.merge": "4.6.1",
-        "lodash.padstart": "4.6.1",
-        "lodash.repeat": "4.1.0",
+        "lodash.find": "^4.6.0",
+        "lodash.max": "^4.0.1",
+        "lodash.merge": "^4.6.0",
+        "lodash.padstart": "^4.6.1",
+        "lodash.repeat": "^4.1.0",
         "sprintf-js": "1.1.0"
       },
       "dependencies": {
@@ -7519,89 +7520,89 @@
       "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.28.2.tgz",
       "integrity": "sha512-ryNxKhNQvU33M3tvRwk/pVG63ZLiS1R5a2zbrqAS75DSrO3N/sRd/iCr8THr4EPIdnYfGEEWluqig6n6rBzl4A==",
       "requires": {
-        "async": "2.6.0",
-        "big.js": "5.0.3",
-        "binary-querystring": "0.1.2",
-        "bl": "1.2.2",
-        "boom": "7.2.0",
-        "bs58": "4.0.1",
-        "byteman": "1.3.5",
-        "cids": "0.5.3",
-        "debug": "3.1.0",
-        "file-type": "7.7.1",
-        "filesize": "3.6.1",
-        "fsm-event": "2.1.0",
-        "get-folder-size": "1.0.1",
-        "glob": "7.1.2",
-        "hapi": "16.6.3",
-        "hapi-set-header": "1.0.2",
-        "hoek": "5.0.3",
-        "human-to-milliseconds": "1.0.0",
-        "ipfs-api": "18.2.1",
-        "ipfs-bitswap": "0.19.0",
-        "ipfs-block": "0.6.1",
-        "ipfs-block-service": "0.13.0",
-        "ipfs-multipart": "0.1.0",
-        "ipfs-repo": "0.18.7",
-        "ipfs-unixfs": "0.1.14",
-        "ipfs-unixfs-engine": "0.24.4",
-        "ipld": "0.15.0",
-        "is-ipfs": "0.3.2",
-        "is-stream": "1.1.0",
-        "joi": "13.2.0",
-        "joi-browser": "13.0.1",
-        "joi-multiaddr": "1.0.1",
-        "libp2p": "0.18.0",
-        "libp2p-circuit": "0.1.5",
-        "libp2p-floodsub": "0.14.1",
-        "libp2p-kad-dht": "0.8.0",
-        "libp2p-keychain": "0.3.1",
-        "libp2p-mdns": "0.9.2",
-        "libp2p-multiplex": "0.5.1",
-        "libp2p-railing": "0.7.1",
-        "libp2p-secio": "0.9.4",
-        "libp2p-tcp": "0.11.6",
-        "libp2p-webrtc-star": "0.13.4",
-        "libp2p-websocket-star": "0.7.7",
-        "libp2p-websockets": "0.10.5",
-        "lodash.flatmap": "4.5.0",
-        "lodash.get": "4.4.2",
-        "lodash.sortby": "4.7.0",
-        "lodash.values": "4.3.0",
-        "mafmt": "4.0.0",
-        "mime-types": "2.1.18",
-        "mkdirp": "0.5.1",
-        "multiaddr": "3.1.0",
-        "multihashes": "0.4.13",
-        "once": "1.4.0",
-        "path-exists": "3.0.0",
-        "peer-book": "0.5.4",
-        "peer-id": "0.10.7",
-        "peer-info": "0.11.6",
-        "progress": "2.0.0",
-        "prom-client": "10.2.3",
-        "prometheus-gc-stats": "0.5.1",
-        "promisify-es6": "1.0.3",
-        "pull-abortable": "4.1.1",
-        "pull-defer": "0.2.2",
-        "pull-file": "1.1.0",
-        "pull-ndjson": "0.1.1",
-        "pull-paramap": "1.2.2",
-        "pull-pushable": "2.2.0",
-        "pull-sort": "1.0.1",
-        "pull-stream": "3.6.7",
-        "pull-stream-to-stream": "1.3.4",
-        "pull-zip": "2.0.1",
-        "read-pkg-up": "3.0.0",
+        "async": "^2.6.0",
+        "big.js": "^5.0.3",
+        "binary-querystring": "~0.1.2",
+        "bl": "^1.2.1",
+        "boom": "^7.1.1",
+        "bs58": "^4.0.1",
+        "byteman": "^1.3.5",
+        "cids": "~0.5.2",
+        "debug": "^3.1.0",
+        "file-type": "^7.6.0",
+        "filesize": "^3.6.0",
+        "fsm-event": "^2.1.0",
+        "get-folder-size": "^1.0.1",
+        "glob": "^7.1.2",
+        "hapi": "^16.6.2",
+        "hapi-set-header": "^1.0.2",
+        "hoek": "^5.0.3",
+        "human-to-milliseconds": "^1.0.0",
+        "ipfs-api": "^18.1.2",
+        "ipfs-bitswap": "~0.19.0",
+        "ipfs-block": "~0.6.1",
+        "ipfs-block-service": "~0.13.0",
+        "ipfs-multipart": "~0.1.0",
+        "ipfs-repo": "~0.18.7",
+        "ipfs-unixfs": "~0.1.14",
+        "ipfs-unixfs-engine": "~0.24.4",
+        "ipld": "^0.15.0",
+        "is-ipfs": "^0.3.2",
+        "is-stream": "^1.1.0",
+        "joi": "^13.1.2",
+        "joi-browser": "^13.0.1",
+        "joi-multiaddr": "^1.0.1",
+        "libp2p": "~0.18.0",
+        "libp2p-circuit": "~0.1.4",
+        "libp2p-floodsub": "~0.14.1",
+        "libp2p-kad-dht": "~0.8.0",
+        "libp2p-keychain": "~0.3.1",
+        "libp2p-mdns": "~0.9.2",
+        "libp2p-multiplex": "~0.5.1",
+        "libp2p-railing": "~0.7.1",
+        "libp2p-secio": "~0.9.3",
+        "libp2p-tcp": "~0.11.6",
+        "libp2p-webrtc-star": "~0.13.4",
+        "libp2p-websocket-star": "~0.7.7",
+        "libp2p-websockets": "~0.10.5",
+        "lodash.flatmap": "^4.5.0",
+        "lodash.get": "^4.4.2",
+        "lodash.sortby": "^4.7.0",
+        "lodash.values": "^4.3.0",
+        "mafmt": "^4.0.0",
+        "mime-types": "^2.1.18",
+        "mkdirp": "~0.5.1",
+        "multiaddr": "^3.0.2",
+        "multihashes": "~0.4.13",
+        "once": "^1.4.0",
+        "path-exists": "^3.0.0",
+        "peer-book": "~0.5.4",
+        "peer-id": "~0.10.6",
+        "peer-info": "~0.11.6",
+        "progress": "^2.0.0",
+        "prom-client": "^10.2.2",
+        "prometheus-gc-stats": "^0.5.0",
+        "promisify-es6": "^1.0.3",
+        "pull-abortable": "^4.1.1",
+        "pull-defer": "^0.2.2",
+        "pull-file": "^1.1.0",
+        "pull-ndjson": "^0.1.1",
+        "pull-paramap": "^1.2.2",
+        "pull-pushable": "^2.2.0",
+        "pull-sort": "^1.0.1",
+        "pull-stream": "^3.6.2",
+        "pull-stream-to-stream": "^1.3.4",
+        "pull-zip": "^2.0.1",
+        "read-pkg-up": "^3.0.0",
         "readable-stream": "2.3.4",
-        "safe-buffer": "5.1.1",
-        "stream-to-pull-stream": "1.7.2",
-        "tar-stream": "1.6.0",
-        "temp": "0.8.3",
-        "through2": "2.0.3",
-        "update-notifier": "2.5.0",
-        "yargs": "11.0.0",
-        "yargs-parser": "9.0.2"
+        "safe-buffer": "^5.1.1",
+        "stream-to-pull-stream": "^1.7.2",
+        "tar-stream": "^1.5.5",
+        "temp": "~0.8.3",
+        "through2": "^2.0.3",
+        "update-notifier": "^2.3.0",
+        "yargs": "^11.0.0",
+        "yargs-parser": "^9.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -7614,7 +7615,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "big.js": {
@@ -7627,7 +7628,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
           "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
           "requires": {
-            "hoek": "5.0.3"
+            "hoek": "5.x.x"
           }
         },
         "cliui": {
@@ -7635,9 +7636,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "requires": {
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "filesize": {
@@ -7660,10 +7661,10 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
           "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "4.0.0",
-            "pify": "3.0.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "mime-db": {
@@ -7676,7 +7677,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
           "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "requires": {
-            "mime-db": "1.33.0"
+            "mime-db": "~1.33.0"
           }
         },
         "parse-json": {
@@ -7684,8 +7685,8 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
           "requires": {
-            "error-ex": "1.3.1",
-            "json-parse-better-errors": "1.0.2"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
         },
         "path-type": {
@@ -7693,7 +7694,7 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "process-nextick-args": {
@@ -7706,9 +7707,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
           "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
           "requires": {
-            "load-json-file": "4.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "3.0.0"
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
@@ -7716,8 +7717,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
           "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "3.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
         "readable-stream": {
@@ -7725,13 +7726,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
           "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string-width": {
@@ -7739,8 +7740,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -7748,7 +7749,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "yargs": {
@@ -7756,18 +7757,18 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
           "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
           "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "9.0.2"
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
           }
         },
         "yargs-parser": {
@@ -7775,7 +7776,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
           "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "requires": {
-            "camelcase": "4.1.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -7785,36 +7786,36 @@
       "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-18.2.1.tgz",
       "integrity": "sha512-ffT6tO4KkACztnA3wm2R1hanQLjyeYgTaaXLtoetMvdKTuI6JeOuwg7lv7HfLpIBRKfeYU98e2wzH7Vv7bhERw==",
       "requires": {
-        "async": "2.6.0",
-        "big.js": "5.0.3",
-        "bs58": "4.0.1",
-        "cids": "0.5.3",
-        "concat-stream": "1.6.2",
-        "detect-node": "2.0.3",
+        "async": "^2.6.0",
+        "big.js": "^5.0.3",
+        "bs58": "^4.0.1",
+        "cids": "~0.5.3",
+        "concat-stream": "^1.6.2",
+        "detect-node": "^2.0.3",
         "flatmap": "0.0.3",
-        "glob": "7.1.2",
-        "ipfs-block": "0.6.1",
-        "ipfs-unixfs": "0.1.14",
-        "ipld-dag-pb": "0.13.1",
-        "is-ipfs": "0.3.2",
-        "is-stream": "1.1.0",
-        "lru-cache": "4.1.2",
-        "multiaddr": "3.1.0",
-        "multihashes": "0.4.13",
-        "ndjson": "1.5.0",
-        "once": "1.4.0",
-        "peer-id": "0.10.7",
-        "peer-info": "0.11.6",
-        "promisify-es6": "1.0.3",
-        "pull-defer": "0.2.2",
-        "pull-pushable": "2.2.0",
-        "pump": "3.0.0",
-        "qs": "6.5.1",
-        "readable-stream": "2.3.6",
-        "stream-http": "2.8.1",
-        "stream-to-pull-stream": "1.7.2",
-        "streamifier": "0.1.1",
-        "tar-stream": "1.6.0"
+        "glob": "^7.1.2",
+        "ipfs-block": "~0.6.1",
+        "ipfs-unixfs": "~0.1.14",
+        "ipld-dag-pb": "~0.13.1",
+        "is-ipfs": "^0.3.2",
+        "is-stream": "^1.1.0",
+        "lru-cache": "^4.1.2",
+        "multiaddr": "^3.0.2",
+        "multihashes": "~0.4.13",
+        "ndjson": "^1.5.0",
+        "once": "^1.4.0",
+        "peer-id": "~0.10.6",
+        "peer-info": "~0.11.6",
+        "promisify-es6": "^1.0.3",
+        "pull-defer": "^0.2.2",
+        "pull-pushable": "^2.2.0",
+        "pump": "^3.0.0",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.3.5",
+        "stream-http": "^2.8.1",
+        "stream-to-pull-stream": "^1.7.2",
+        "streamifier": "^0.1.1",
+        "tar-stream": "^1.5.5"
       },
       "dependencies": {
         "async": {
@@ -7822,7 +7823,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "big.js": {
@@ -7835,10 +7836,10 @@
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "requires": {
-            "buffer-from": "1.0.0",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6",
-            "typedarray": "0.0.6"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         },
         "lru-cache": {
@@ -7846,8 +7847,8 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
           "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "process-nextick-args": {
@@ -7860,8 +7861,8 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "requires": {
-            "end-of-stream": "1.4.0",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "readable-stream": {
@@ -7869,13 +7870,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "stream-http": {
@@ -7883,11 +7884,11 @@
           "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz",
           "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
           "requires": {
-            "builtin-status-codes": "3.0.0",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6",
-            "to-arraybuffer": "1.0.1",
-            "xtend": "4.0.1"
+            "builtin-status-codes": "^3.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.3.3",
+            "to-arraybuffer": "^1.0.0",
+            "xtend": "^4.0.0"
           }
         },
         "string_decoder": {
@@ -7895,7 +7896,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -7905,30 +7906,30 @@
       "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-0.19.0.tgz",
       "integrity": "sha512-TF+wi6tYaWusJatJROlKOP4XftIf4cW8YVu6+5iIZ1oezon0I5eKRwh4iRd1HtOqyRckXrGgy8mg6rvWyGpaiA==",
       "requires": {
-        "async": "2.6.0",
-        "big.js": "5.0.3",
-        "cids": "0.5.3",
-        "debug": "3.1.0",
-        "ipfs-block": "0.6.1",
-        "lodash.debounce": "4.0.8",
-        "lodash.find": "4.6.0",
-        "lodash.groupby": "4.6.0",
-        "lodash.isequalwith": "4.4.0",
-        "lodash.isundefined": "3.0.1",
-        "lodash.pullallwith": "4.7.0",
-        "lodash.sortby": "4.7.0",
-        "lodash.uniqwith": "4.5.0",
-        "lodash.values": "4.3.0",
-        "moving-average": "1.0.0",
-        "multicodec": "0.2.6",
-        "multihashing-async": "0.4.8",
-        "protons": "1.0.1",
-        "pull-defer": "0.2.2",
-        "pull-length-prefixed": "1.3.0",
-        "pull-pushable": "2.2.0",
-        "pull-stream": "3.6.7",
-        "safe-buffer": "5.1.1",
-        "varint-decoder": "0.1.1"
+        "async": "^2.6.0",
+        "big.js": "^5.0.3",
+        "cids": "~0.5.2",
+        "debug": "^3.1.0",
+        "ipfs-block": "~0.6.1",
+        "lodash.debounce": "^4.0.8",
+        "lodash.find": "^4.6.0",
+        "lodash.groupby": "^4.6.0",
+        "lodash.isequalwith": "^4.4.0",
+        "lodash.isundefined": "^3.0.1",
+        "lodash.pullallwith": "^4.7.0",
+        "lodash.sortby": "^4.7.0",
+        "lodash.uniqwith": "^4.5.0",
+        "lodash.values": "^4.3.0",
+        "moving-average": "^1.0.0",
+        "multicodec": "~0.2.6",
+        "multihashing-async": "~0.4.7",
+        "protons": "^1.0.1",
+        "pull-defer": "~0.2.2",
+        "pull-length-prefixed": "^1.3.0",
+        "pull-pushable": "^2.1.2",
+        "pull-stream": "^3.6.1",
+        "safe-buffer": "^5.1.1",
+        "varint-decoder": "^0.1.1"
       },
       "dependencies": {
         "async": {
@@ -7936,7 +7937,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "big.js": {
@@ -7951,7 +7952,7 @@
       "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.6.1.tgz",
       "integrity": "sha512-28dgGsb2YsYnFs+To4cVBX8e/lTCb8eWDzGhN5csj3a/sHMOYrHeK8+Ez0IV67CI3lqKGuG/ZD01Cmd6JUvKrQ==",
       "requires": {
-        "cids": "0.5.3"
+        "cids": "^0.5.2"
       }
     },
     "ipfs-block-service": {
@@ -7964,8 +7965,8 @@
       "resolved": "https://registry.npmjs.org/ipfs-multipart/-/ipfs-multipart-0.1.0.tgz",
       "integrity": "sha1-Wo7RP0LoLYvvfS4VHY6vXjow4+o=",
       "requires": {
-        "content": "3.0.7",
-        "dicer": "0.2.5"
+        "content": "^3.0.0",
+        "dicer": "^0.2.5"
       }
     },
     "ipfs-pubsub-room": {
@@ -7973,11 +7974,11 @@
       "resolved": "https://registry.npmjs.org/ipfs-pubsub-room/-/ipfs-pubsub-room-1.2.0.tgz",
       "integrity": "sha512-NPAyPF670n4S8Mse7wodVbbzxPwHVgHKV0QqIliO4NM8u88kZhttPi1/jume9MLtqAIgleSrnrYZ6qqaaoRP1A==",
       "requires": {
-        "hyperdiff": "2.0.4",
-        "lodash.clonedeep": "4.5.0",
-        "pull-pushable": "2.2.0",
-        "pull-stream": "3.6.7",
-        "safe-buffer": "5.1.1"
+        "hyperdiff": "^2.0.3",
+        "lodash.clonedeep": "^4.5.0",
+        "pull-pushable": "^2.1.1",
+        "pull-stream": "^3.6.1",
+        "safe-buffer": "^5.1.1"
       }
     },
     "ipfs-repo": {
@@ -7985,24 +7986,24 @@
       "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-0.18.7.tgz",
       "integrity": "sha512-a1gXPX2UA/8rE63/E5X7+QB7jvmNYD+mVHSX0ypb7ZIsMoc0ewiq5Bwc2NXQAN7PCNWksxp1tDGWzq6bAPm9vg==",
       "requires": {
-        "async": "2.6.0",
-        "base32.js": "0.1.0",
-        "big.js": "5.0.3",
-        "cids": "0.5.3",
-        "datastore-core": "0.4.0",
-        "datastore-fs": "0.4.2",
-        "datastore-level": "0.7.0",
-        "debug": "3.1.0",
-        "interface-datastore": "0.4.2",
-        "ipfs-block": "0.6.1",
+        "async": "^2.6.0",
+        "base32.js": "~0.1.0",
+        "big.js": "^5.0.3",
+        "cids": "~0.5.2",
+        "datastore-core": "~0.4.0",
+        "datastore-fs": "~0.4.2",
+        "datastore-level": "~0.7.0",
+        "debug": "^3.1.0",
+        "interface-datastore": "~0.4.2",
+        "ipfs-block": "~0.6.1",
         "level-js": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
-        "leveldown": "1.9.0",
-        "lock-me": "1.0.3",
-        "lodash.get": "4.4.2",
-        "lodash.has": "4.5.2",
-        "lodash.set": "4.3.2",
-        "multiaddr": "3.1.0",
-        "pull-stream": "3.6.7"
+        "leveldown": "^1.7.2",
+        "lock-me": "^1.0.3",
+        "lodash.get": "^4.4.2",
+        "lodash.has": "^4.5.2",
+        "lodash.set": "^4.3.2",
+        "multiaddr": "^3.0.1",
+        "pull-stream": "^3.6.1"
       },
       "dependencies": {
         "async": {
@@ -8010,7 +8011,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "big.js": {
@@ -8025,7 +8026,7 @@
       "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-0.1.14.tgz",
       "integrity": "sha512-s1tEnwKhdd17MmyC/EUMNVMDYzKhCiHDI11TF8tSBeWkEQp+0WUxkYuqvz0R5TSi2lNDJ/oVnEmwWhki2spUiQ==",
       "requires": {
-        "protons": "1.0.1"
+        "protons": "^1.0.0"
       }
     },
     "ipfs-unixfs-engine": {
@@ -8033,28 +8034,28 @@
       "resolved": "https://registry.npmjs.org/ipfs-unixfs-engine/-/ipfs-unixfs-engine-0.24.4.tgz",
       "integrity": "sha512-dioocJXylmdWRMUR/9WqRn8EYOj0VGrSYFTTdy2Z2WJdOGhnb+C+ubkGTyewmkAFDWoxaqCcwwPRbos3PjqIUQ==",
       "requires": {
-        "async": "2.6.0",
-        "bs58": "4.0.1",
-        "cids": "0.5.3",
-        "deep-extend": "0.5.1",
-        "ipfs-unixfs": "0.1.14",
-        "ipld": "0.15.0",
-        "ipld-dag-pb": "0.13.1",
-        "left-pad": "1.3.0",
-        "lodash": "4.17.10",
-        "multihashes": "0.4.13",
-        "multihashing-async": "0.4.8",
-        "pull-batch": "1.0.0",
-        "pull-block": "1.4.0",
-        "pull-cat": "1.1.11",
-        "pull-pair": "1.1.0",
-        "pull-paramap": "1.2.2",
+        "async": "^2.6.0",
+        "bs58": "^4.0.1",
+        "cids": "~0.5.2",
+        "deep-extend": "~0.5.0",
+        "ipfs-unixfs": "~0.1.14",
+        "ipld": "^0.15.0",
+        "ipld-dag-pb": "~0.13.1",
+        "left-pad": "^1.2.0",
+        "lodash": "^4.17.5",
+        "multihashes": "~0.4.13",
+        "multihashing-async": "~0.4.8",
+        "pull-batch": "^1.0.0",
+        "pull-block": "^1.4.0",
+        "pull-cat": "^1.1.11",
+        "pull-pair": "^1.1.0",
+        "pull-paramap": "^1.2.2",
         "pull-pause": "0.0.2",
-        "pull-pushable": "2.2.0",
-        "pull-stream": "3.6.7",
-        "pull-traverse": "1.0.3",
-        "pull-write": "1.1.4",
-        "sparse-array": "1.3.1"
+        "pull-pushable": "^2.2.0",
+        "pull-stream": "^3.6.2",
+        "pull-traverse": "^1.0.3",
+        "pull-write": "^1.1.4",
+        "sparse-array": "^1.3.1"
       },
       "dependencies": {
         "async": {
@@ -8062,7 +8063,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.10"
+            "lodash": "^4.14.0"
           }
         },
         "deep-extend": {
@@ -8082,28 +8083,28 @@
       "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.15.0.tgz",
       "integrity": "sha512-/7aeDrd/SRBerJNAmGzWA2Iu61IQrkIJ4tiU0Sf/ZZeawuIIriH5KhQyFnPiTZk8a5tcEnCoqhzh6N++zpFccQ==",
       "requires": {
-        "async": "2.6.0",
-        "cids": "0.5.3",
-        "interface-datastore": "0.4.2",
-        "ipfs-block": "0.6.1",
-        "ipfs-block-service": "0.13.0",
-        "ipfs-repo": "0.18.7",
-        "ipld-bitcoin": "0.1.5",
-        "ipld-dag-cbor": "0.12.0",
-        "ipld-dag-pb": "0.13.1",
-        "ipld-ethereum": "2.0.0",
-        "ipld-git": "0.2.0",
-        "ipld-raw": "2.0.0",
-        "ipld-zcash": "0.1.3",
-        "is-ipfs": "0.3.2",
-        "lodash.flatten": "4.4.0",
-        "lodash.includes": "4.3.0",
-        "memdown": "1.4.1",
-        "multihashes": "0.4.13",
-        "pull-defer": "0.2.2",
-        "pull-sort": "1.0.1",
-        "pull-stream": "3.6.7",
-        "pull-traverse": "1.0.3"
+        "async": "^2.6.0",
+        "cids": "~0.5.2",
+        "interface-datastore": "~0.4.2",
+        "ipfs-block": "~0.6.1",
+        "ipfs-block-service": "~0.13.0",
+        "ipfs-repo": "~0.18.5",
+        "ipld-bitcoin": "~0.1.5",
+        "ipld-dag-cbor": "~0.12.0",
+        "ipld-dag-pb": "~0.13.0",
+        "ipld-ethereum": "^2.0.0",
+        "ipld-git": "~0.2.0",
+        "ipld-raw": "^2.0.0",
+        "ipld-zcash": "~0.1.3",
+        "is-ipfs": "~0.3.2",
+        "lodash.flatten": "^4.4.0",
+        "lodash.includes": "^4.3.0",
+        "memdown": "^1.4.1",
+        "multihashes": "~0.4.12",
+        "pull-defer": "^0.2.2",
+        "pull-sort": "^1.0.1",
+        "pull-stream": "^3.6.1",
+        "pull-traverse": "^1.0.3"
       },
       "dependencies": {
         "async": {
@@ -8111,7 +8112,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         }
       }
@@ -8121,11 +8122,11 @@
       "resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.1.5.tgz",
       "integrity": "sha512-sXgjbp++QTs1onkeBY/W1/LTvDdFErZoPgPlIKAOR9fiLXaRHSUKHTBulaL/IDnNXhD5jaFPveOudFkNNJCbDw==",
       "requires": {
-        "bitcoinjs-lib": "3.3.2",
-        "cids": "0.5.3",
-        "dirty-chai": "2.0.1",
-        "hash.js": "1.1.3",
-        "multihashes": "0.4.13"
+        "bitcoinjs-lib": "^3.3.2",
+        "cids": "~0.5.2",
+        "dirty-chai": "^2.0.1",
+        "hash.js": "^1.1.3",
+        "multihashes": "~0.4.12"
       }
     },
     "ipld-dag-cbor": {
@@ -8133,14 +8134,14 @@
       "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.12.0.tgz",
       "integrity": "sha512-zitoqSGNP/73r5LU4ZuYE5E+zJar84k+AEGdFl3Y+H3opBn8KTMcR3bm1CoTaJYBfpn1fJpB0jb2wTEQDRESpQ==",
       "requires": {
-        "async": "2.6.0",
-        "borc": "2.0.2",
-        "bs58": "4.0.1",
-        "cids": "0.5.3",
-        "is-circular": "1.0.1",
-        "multihashes": "0.4.13",
-        "multihashing-async": "0.4.8",
-        "traverse": "0.6.6"
+        "async": "^2.6.0",
+        "borc": "^2.0.2",
+        "bs58": "^4.0.1",
+        "cids": "~0.5.2",
+        "is-circular": "^1.0.1",
+        "multihashes": "~0.4.12",
+        "multihashing-async": "~0.4.7",
+        "traverse": "^0.6.6"
       },
       "dependencies": {
         "async": {
@@ -8148,7 +8149,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         }
       }
@@ -8158,18 +8159,18 @@
       "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.13.1.tgz",
       "integrity": "sha512-HxybRQvpY8IQ9T0bImlT5v4LBR3jJAgEnFRA/ZU2UNIiBuRkbirI9+VSX03+WkiYooiFMoZz6Qp/xYMdoogNWg==",
       "requires": {
-        "async": "2.6.0",
-        "bs58": "4.0.1",
+        "async": "^2.6.0",
+        "bs58": "^4.0.1",
         "buffer-loader": "0.0.1",
-        "cids": "0.5.3",
-        "ipfs-block": "0.6.1",
-        "is-ipfs": "0.3.2",
-        "multihashes": "0.4.13",
-        "multihashing-async": "0.4.8",
-        "protons": "1.0.1",
-        "pull-stream": "3.6.7",
-        "pull-traverse": "1.0.3",
-        "stable": "0.1.8"
+        "cids": "~0.5.2",
+        "ipfs-block": "~0.6.1",
+        "is-ipfs": "~0.3.2",
+        "multihashes": "~0.4.12",
+        "multihashing-async": "~0.4.7",
+        "protons": "^1.0.1",
+        "pull-stream": "^3.6.1",
+        "pull-traverse": "^1.0.3",
+        "stable": "^0.1.6"
       },
       "dependencies": {
         "async": {
@@ -8177,7 +8178,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         }
       }
@@ -8187,17 +8188,17 @@
       "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-2.0.0.tgz",
       "integrity": "sha512-wpWmba4bwjctTrHZbYQIdbizCBprEh4ueDhAJtYiiaEoDA4yWdrDF/gHNL3dBXFMFZ/FYudSI08GrQeEuC8tQg==",
       "requires": {
-        "async": "2.6.0",
-        "cids": "0.5.3",
-        "eth-hash-to-cid": "0.1.1",
-        "ethereumjs-account": "2.0.4",
-        "ethereumjs-block": "1.7.1",
-        "ethereumjs-tx": "1.3.4",
-        "ipfs-block": "0.6.1",
-        "merkle-patricia-tree": "2.3.1",
-        "multihashes": "0.4.13",
-        "multihashing-async": "0.4.8",
-        "rlp": "2.0.0"
+        "async": "^2.6.0",
+        "cids": "~0.5.2",
+        "eth-hash-to-cid": "~0.1.0",
+        "ethereumjs-account": "^2.0.4",
+        "ethereumjs-block": "^1.7.0",
+        "ethereumjs-tx": "^1.3.3",
+        "ipfs-block": "~0.6.1",
+        "merkle-patricia-tree": "^2.2.0",
+        "multihashes": "~0.4.12",
+        "multihashing-async": "~0.4.7",
+        "rlp": "^2.0.0"
       },
       "dependencies": {
         "async": {
@@ -8205,7 +8206,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         }
       }
@@ -8215,13 +8216,13 @@
       "resolved": "https://registry.npmjs.org/ipld-git/-/ipld-git-0.2.0.tgz",
       "integrity": "sha512-4hMxkRCIme5qlqxgtQ9ZKsU+LmbNu55Yqi9MTNPly6tOPuBdNcB/5Cvw9OBG8KPHaGpZkHYmZ1K/LTHD0M7FCg==",
       "requires": {
-        "async": "2.6.0",
-        "cids": "0.5.3",
-        "multicodec": "0.2.6",
-        "multihashes": "0.4.13",
-        "multihashing-async": "0.4.8",
-        "smart-buffer": "4.0.1",
-        "traverse": "0.6.6"
+        "async": "^2.6.0",
+        "cids": "~0.5.2",
+        "multicodec": "~0.2.5",
+        "multihashes": "~0.4.12",
+        "multihashing-async": "~0.4.7",
+        "smart-buffer": "^4.0.0",
+        "traverse": "~0.6.6"
       },
       "dependencies": {
         "async": {
@@ -8229,7 +8230,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         }
       }
@@ -8239,7 +8240,7 @@
       "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-2.0.0.tgz",
       "integrity": "sha512-iuzlzyqIMnRjpsgyVcorkXIXRZjlYjdlmZFpYW5K1s2ce5qnl4DHy4o7ASsgIpr3Eevp4BuwMXnJBpK6i8u8qg==",
       "requires": {
-        "cids": "0.5.3"
+        "cids": "~0.5.2"
       }
     },
     "ipld-zcash": {
@@ -8247,11 +8248,11 @@
       "resolved": "https://registry.npmjs.org/ipld-zcash/-/ipld-zcash-0.1.3.tgz",
       "integrity": "sha512-SLMihJHMTjU008iSAUEVILKgpcRbhEhu/VZQ4Arcj3WnB18AdDZAwC7hg6E8BeJDG7oJq5vtfJ68YxRX9NSHgg==",
       "requires": {
-        "cids": "0.5.3",
-        "dirty-chai": "2.0.1",
-        "hash.js": "1.1.3",
-        "multihashes": "0.4.13",
-        "zcash-bitcore-lib": "0.13.20-rc3"
+        "cids": "~0.5.2",
+        "dirty-chai": "^2.0.1",
+        "hash.js": "^1.1.3",
+        "multihashes": "~0.4.12",
+        "zcash-bitcore-lib": "^0.13.20-rc3"
       }
     },
     "iron": {
@@ -8259,9 +8260,9 @@
       "resolved": "https://registry.npmjs.org/iron/-/iron-4.0.5.tgz",
       "integrity": "sha1-TwQszri5c480a1mqc0yDqJvDFCg=",
       "requires": {
-        "boom": "5.2.0",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0"
+        "boom": "5.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x"
       }
     },
     "is-absolute-url": {
@@ -8284,8 +8285,8 @@
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz",
       "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
       "requires": {
-        "is-alphabetical": "1.0.2",
-        "is-decimal": "1.0.2"
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
       }
     },
     "is-arrayish": {
@@ -8298,7 +8299,7 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "requires": {
-        "binary-extensions": "1.10.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -8311,7 +8312,7 @@
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-callable": {
@@ -8324,7 +8325,7 @@
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "requires": {
-        "ci-info": "1.1.1"
+        "ci-info": "^1.0.0"
       }
     },
     "is-circular": {
@@ -8357,7 +8358,7 @@
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -8375,7 +8376,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -8383,7 +8384,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-glob": {
@@ -8391,7 +8392,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-hex-prefixed": {
@@ -8409,8 +8410,8 @@
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "requires": {
-        "global-dirs": "0.1.1",
-        "is-path-inside": "1.0.0"
+        "global-dirs": "^0.1.0",
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-ipfs": {
@@ -8418,9 +8419,9 @@
       "resolved": "https://registry.npmjs.org/is-ipfs/-/is-ipfs-0.3.2.tgz",
       "integrity": "sha512-82V1j4LMkYy7H4seQQzOWqo7FiW3I64/1/ryo3dhtWKfOvm7ZolLMRQQfGKs4OXWauh5rAkPnamVcRISHwhmpQ==",
       "requires": {
-        "bs58": "4.0.1",
-        "cids": "0.5.3",
-        "multihashes": "0.4.13"
+        "bs58": "^4.0.1",
+        "cids": "~0.5.1",
+        "multihashes": "~0.4.9"
       }
     },
     "is-npm": {
@@ -8433,7 +8434,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-obj": {
@@ -8451,7 +8452,7 @@
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -8459,7 +8460,7 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-obj": {
@@ -8492,7 +8493,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
-        "has": "1.0.1"
+        "has": "^1.0.1"
       }
     },
     "is-resolvable": {
@@ -8500,7 +8501,7 @@
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
       "requires": {
-        "tryit": "1.0.3"
+        "tryit": "^1.0.1"
       }
     },
     "is-retry-allowed": {
@@ -8529,7 +8530,7 @@
       "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
       "requires": {
-        "html-comment-regex": "1.1.1"
+        "html-comment-regex": "^1.1.0"
       }
     },
     "is-symbol": {
@@ -8600,8 +8601,8 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
+        "node-fetch": "^1.0.1",
+        "whatwg-fetch": ">=0.10.0"
       }
     },
     "isstream": {
@@ -8614,17 +8615,17 @@
       "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.14.tgz",
       "integrity": "sha1-JbxXAffGgMD//5E95G42GaOm5oA=",
       "requires": {
-        "async": "2.5.0",
-        "fileset": "2.0.3",
-        "istanbul-lib-coverage": "1.1.1",
-        "istanbul-lib-hook": "1.0.7",
-        "istanbul-lib-instrument": "1.8.0",
-        "istanbul-lib-report": "1.1.1",
-        "istanbul-lib-source-maps": "1.2.1",
-        "istanbul-reports": "1.1.2",
-        "js-yaml": "3.7.0",
-        "mkdirp": "0.5.1",
-        "once": "1.4.0"
+        "async": "^2.1.4",
+        "fileset": "^2.0.2",
+        "istanbul-lib-coverage": "^1.1.1",
+        "istanbul-lib-hook": "^1.0.7",
+        "istanbul-lib-instrument": "^1.8.0",
+        "istanbul-lib-report": "^1.1.1",
+        "istanbul-lib-source-maps": "^1.2.1",
+        "istanbul-reports": "^1.1.2",
+        "js-yaml": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0"
       }
     },
     "istanbul-lib-coverage": {
@@ -8637,7 +8638,7 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
       "integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ==",
       "requires": {
-        "append-transform": "0.4.0"
+        "append-transform": "^0.4.0"
       }
     },
     "istanbul-lib-instrument": {
@@ -8645,13 +8646,13 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.8.0.tgz",
       "integrity": "sha1-ZvbJQhzJ7EcE928tsIS6kHiitTI=",
       "requires": {
-        "babel-generator": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "istanbul-lib-coverage": "1.1.1",
-        "semver": "5.4.1"
+        "babel-generator": "^6.18.0",
+        "babel-template": "^6.16.0",
+        "babel-traverse": "^6.18.0",
+        "babel-types": "^6.18.0",
+        "babylon": "^6.18.0",
+        "istanbul-lib-coverage": "^1.1.1",
+        "semver": "^5.3.0"
       }
     },
     "istanbul-lib-report": {
@@ -8659,10 +8660,10 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
       "integrity": "sha512-tvF+YmCmH4thnez6JFX06ujIA19WPa9YUiwjc1uALF2cv5dmE3It8b5I8Ob7FHJ70H9Y5yF+TDkVa/mcADuw1Q==",
       "requires": {
-        "istanbul-lib-coverage": "1.1.1",
-        "mkdirp": "0.5.1",
-        "path-parse": "1.0.5",
-        "supports-color": "3.2.3"
+        "istanbul-lib-coverage": "^1.1.1",
+        "mkdirp": "^0.5.1",
+        "path-parse": "^1.0.5",
+        "supports-color": "^3.1.2"
       },
       "dependencies": {
         "has-flag": {
@@ -8675,7 +8676,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -8685,11 +8686,11 @@
       "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
       "integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w==",
       "requires": {
-        "debug": "2.6.9",
-        "istanbul-lib-coverage": "1.1.1",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "source-map": "0.5.7"
+        "debug": "^2.6.3",
+        "istanbul-lib-coverage": "^1.1.1",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.6.1",
+        "source-map": "^0.5.3"
       },
       "dependencies": {
         "debug": {
@@ -8705,7 +8706,7 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         }
       }
@@ -8715,7 +8716,7 @@
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
       "integrity": "sha1-D7Lj9qqZIr085F0F2KtNXo4HvU8=",
       "requires": {
-        "handlebars": "4.0.10"
+        "handlebars": "^4.0.3"
       }
     },
     "items": {
@@ -8728,7 +8729,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-20.0.4.tgz",
       "integrity": "sha1-PdJgwpidba1nix6cxNkZRPbWAqw=",
       "requires": {
-        "jest-cli": "20.0.4"
+        "jest-cli": "^20.0.4"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -8751,8 +8752,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "jest-cli": {
@@ -8760,36 +8761,36 @@
           "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-20.0.4.tgz",
           "integrity": "sha1-5TKxnYiuW8bEF+iwWTpv6VSx3JM=",
           "requires": {
-            "ansi-escapes": "1.4.0",
-            "callsites": "2.0.0",
-            "chalk": "1.1.3",
-            "graceful-fs": "4.1.11",
-            "is-ci": "1.0.10",
-            "istanbul-api": "1.1.14",
-            "istanbul-lib-coverage": "1.1.1",
-            "istanbul-lib-instrument": "1.8.0",
-            "istanbul-lib-source-maps": "1.2.1",
-            "jest-changed-files": "20.0.3",
-            "jest-config": "20.0.4",
-            "jest-docblock": "20.0.3",
-            "jest-environment-jsdom": "20.0.3",
-            "jest-haste-map": "20.0.5",
-            "jest-jasmine2": "20.0.4",
-            "jest-message-util": "20.0.3",
-            "jest-regex-util": "20.0.3",
-            "jest-resolve-dependencies": "20.0.3",
-            "jest-runtime": "20.0.4",
-            "jest-snapshot": "20.0.3",
-            "jest-util": "20.0.3",
-            "micromatch": "2.3.11",
-            "node-notifier": "5.1.2",
-            "pify": "2.3.0",
-            "slash": "1.0.0",
-            "string-length": "1.0.1",
-            "throat": "3.2.0",
-            "which": "1.3.0",
-            "worker-farm": "1.5.0",
-            "yargs": "7.1.0"
+            "ansi-escapes": "^1.4.0",
+            "callsites": "^2.0.0",
+            "chalk": "^1.1.3",
+            "graceful-fs": "^4.1.11",
+            "is-ci": "^1.0.10",
+            "istanbul-api": "^1.1.1",
+            "istanbul-lib-coverage": "^1.0.1",
+            "istanbul-lib-instrument": "^1.4.2",
+            "istanbul-lib-source-maps": "^1.1.0",
+            "jest-changed-files": "^20.0.3",
+            "jest-config": "^20.0.4",
+            "jest-docblock": "^20.0.3",
+            "jest-environment-jsdom": "^20.0.3",
+            "jest-haste-map": "^20.0.4",
+            "jest-jasmine2": "^20.0.4",
+            "jest-message-util": "^20.0.3",
+            "jest-regex-util": "^20.0.3",
+            "jest-resolve-dependencies": "^20.0.3",
+            "jest-runtime": "^20.0.4",
+            "jest-snapshot": "^20.0.3",
+            "jest-util": "^20.0.3",
+            "micromatch": "^2.3.11",
+            "node-notifier": "^5.0.2",
+            "pify": "^2.3.0",
+            "slash": "^1.0.0",
+            "string-length": "^1.0.1",
+            "throat": "^3.0.0",
+            "which": "^1.2.12",
+            "worker-farm": "^1.3.1",
+            "yargs": "^7.0.2"
           }
         },
         "load-json-file": {
@@ -8797,11 +8798,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "os-locale": {
@@ -8809,7 +8810,7 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
-            "lcid": "1.0.0"
+            "lcid": "^1.0.0"
           }
         },
         "path-exists": {
@@ -8817,7 +8818,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -8825,9 +8826,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -8840,9 +8841,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -8850,8 +8851,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "strip-bom": {
@@ -8859,7 +8860,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "which-module": {
@@ -8872,19 +8873,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "5.0.0"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^5.0.0"
           }
         },
         "yargs-parser": {
@@ -8892,7 +8893,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
           "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "requires": {
-            "camelcase": "3.0.0"
+            "camelcase": "^3.0.0"
           }
         }
       }
@@ -8907,16 +8908,16 @@
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-20.0.4.tgz",
       "integrity": "sha1-43kwqyIXyRNgXv8T5712PsSPruo=",
       "requires": {
-        "chalk": "1.1.3",
-        "glob": "7.1.2",
-        "jest-environment-jsdom": "20.0.3",
-        "jest-environment-node": "20.0.3",
-        "jest-jasmine2": "20.0.4",
-        "jest-matcher-utils": "20.0.3",
-        "jest-regex-util": "20.0.3",
-        "jest-resolve": "20.0.4",
-        "jest-validate": "20.0.3",
-        "pretty-format": "20.0.3"
+        "chalk": "^1.1.3",
+        "glob": "^7.1.1",
+        "jest-environment-jsdom": "^20.0.3",
+        "jest-environment-node": "^20.0.3",
+        "jest-jasmine2": "^20.0.4",
+        "jest-matcher-utils": "^20.0.3",
+        "jest-regex-util": "^20.0.3",
+        "jest-resolve": "^20.0.4",
+        "jest-validate": "^20.0.3",
+        "pretty-format": "^20.0.3"
       }
     },
     "jest-diff": {
@@ -8924,10 +8925,10 @@
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-20.0.3.tgz",
       "integrity": "sha1-gfKI/Z5nXw+yPHXxwrGURf5YZhc=",
       "requires": {
-        "chalk": "1.1.3",
-        "diff": "3.3.1",
-        "jest-matcher-utils": "20.0.3",
-        "pretty-format": "20.0.3"
+        "chalk": "^1.1.3",
+        "diff": "^3.2.0",
+        "jest-matcher-utils": "^20.0.3",
+        "pretty-format": "^20.0.3"
       }
     },
     "jest-docblock": {
@@ -8940,9 +8941,9 @@
       "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-20.0.3.tgz",
       "integrity": "sha1-BIqKwS7iJfcZBBdxODS7mZeH3pk=",
       "requires": {
-        "jest-mock": "20.0.3",
-        "jest-util": "20.0.3",
-        "jsdom": "9.12.0"
+        "jest-mock": "^20.0.3",
+        "jest-util": "^20.0.3",
+        "jsdom": "^9.12.0"
       }
     },
     "jest-environment-node": {
@@ -8950,8 +8951,8 @@
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-20.0.3.tgz",
       "integrity": "sha1-1Ii8RhKvLCRumG6K52caCZFj1AM=",
       "requires": {
-        "jest-mock": "20.0.3",
-        "jest-util": "20.0.3"
+        "jest-mock": "^20.0.3",
+        "jest-util": "^20.0.3"
       }
     },
     "jest-haste-map": {
@@ -8959,12 +8960,12 @@
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.0.5.tgz",
       "integrity": "sha512-0IKAQjUvuZjMCNi/0VNQQF74/H9KB67hsHJqGiwTWQC6XO5Azs7kLWm+6Q/dwuhvDUvABDOBMFK2/FwZ3sZ07Q==",
       "requires": {
-        "fb-watchman": "2.0.0",
-        "graceful-fs": "4.1.11",
-        "jest-docblock": "20.0.3",
-        "micromatch": "2.3.11",
-        "sane": "1.6.0",
-        "worker-farm": "1.5.0"
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.1.11",
+        "jest-docblock": "^20.0.3",
+        "micromatch": "^2.3.11",
+        "sane": "~1.6.0",
+        "worker-farm": "^1.3.1"
       }
     },
     "jest-jasmine2": {
@@ -8972,15 +8973,15 @@
       "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-20.0.4.tgz",
       "integrity": "sha1-/MWxQReA2RHQQpAu8YWehS5g1eE=",
       "requires": {
-        "chalk": "1.1.3",
-        "graceful-fs": "4.1.11",
-        "jest-diff": "20.0.3",
-        "jest-matcher-utils": "20.0.3",
-        "jest-matchers": "20.0.3",
-        "jest-message-util": "20.0.3",
-        "jest-snapshot": "20.0.3",
-        "once": "1.4.0",
-        "p-map": "1.2.0"
+        "chalk": "^1.1.3",
+        "graceful-fs": "^4.1.11",
+        "jest-diff": "^20.0.3",
+        "jest-matcher-utils": "^20.0.3",
+        "jest-matchers": "^20.0.3",
+        "jest-message-util": "^20.0.3",
+        "jest-snapshot": "^20.0.3",
+        "once": "^1.4.0",
+        "p-map": "^1.1.1"
       }
     },
     "jest-matcher-utils": {
@@ -8988,8 +8989,8 @@
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz",
       "integrity": "sha1-s6a443yld4A7CDKpixZPRLeBVhI=",
       "requires": {
-        "chalk": "1.1.3",
-        "pretty-format": "20.0.3"
+        "chalk": "^1.1.3",
+        "pretty-format": "^20.0.3"
       }
     },
     "jest-matchers": {
@@ -8997,10 +8998,10 @@
       "resolved": "https://registry.npmjs.org/jest-matchers/-/jest-matchers-20.0.3.tgz",
       "integrity": "sha1-ymnbHDLbWm9wf6XgQBq7VXAN/WA=",
       "requires": {
-        "jest-diff": "20.0.3",
-        "jest-matcher-utils": "20.0.3",
-        "jest-message-util": "20.0.3",
-        "jest-regex-util": "20.0.3"
+        "jest-diff": "^20.0.3",
+        "jest-matcher-utils": "^20.0.3",
+        "jest-message-util": "^20.0.3",
+        "jest-regex-util": "^20.0.3"
       }
     },
     "jest-message-util": {
@@ -9008,9 +9009,9 @@
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-20.0.3.tgz",
       "integrity": "sha1-auwoRDBvyw5udNV5bBAG2W/dgxw=",
       "requires": {
-        "chalk": "1.1.3",
-        "micromatch": "2.3.11",
-        "slash": "1.0.0"
+        "chalk": "^1.1.3",
+        "micromatch": "^2.3.11",
+        "slash": "^1.0.0"
       }
     },
     "jest-mock": {
@@ -9028,9 +9029,9 @@
       "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-20.0.4.tgz",
       "integrity": "sha1-lEiz6La6/BVHlETGSZBFt//ll6U=",
       "requires": {
-        "browser-resolve": "1.11.2",
-        "is-builtin-module": "1.0.0",
-        "resolve": "1.4.0"
+        "browser-resolve": "^1.11.2",
+        "is-builtin-module": "^1.0.0",
+        "resolve": "^1.3.2"
       }
     },
     "jest-resolve-dependencies": {
@@ -9038,7 +9039,7 @@
       "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-20.0.3.tgz",
       "integrity": "sha1-bhSntxevDyyzZnxUneQK8Bexcjo=",
       "requires": {
-        "jest-regex-util": "20.0.3"
+        "jest-regex-util": "^20.0.3"
       }
     },
     "jest-runtime": {
@@ -9046,21 +9047,21 @@
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-20.0.4.tgz",
       "integrity": "sha1-osgCIZxCA/dU3xQE5JAYYWnRJNg=",
       "requires": {
-        "babel-core": "6.25.0",
-        "babel-jest": "20.0.3",
-        "babel-plugin-istanbul": "4.1.5",
-        "chalk": "1.1.3",
-        "convert-source-map": "1.5.0",
-        "graceful-fs": "4.1.11",
-        "jest-config": "20.0.4",
-        "jest-haste-map": "20.0.5",
-        "jest-regex-util": "20.0.3",
-        "jest-resolve": "20.0.4",
-        "jest-util": "20.0.3",
-        "json-stable-stringify": "1.0.1",
-        "micromatch": "2.3.11",
+        "babel-core": "^6.0.0",
+        "babel-jest": "^20.0.3",
+        "babel-plugin-istanbul": "^4.0.0",
+        "chalk": "^1.1.3",
+        "convert-source-map": "^1.4.0",
+        "graceful-fs": "^4.1.11",
+        "jest-config": "^20.0.4",
+        "jest-haste-map": "^20.0.4",
+        "jest-regex-util": "^20.0.3",
+        "jest-resolve": "^20.0.4",
+        "jest-util": "^20.0.3",
+        "json-stable-stringify": "^1.0.1",
+        "micromatch": "^2.3.11",
         "strip-bom": "3.0.0",
-        "yargs": "7.1.0"
+        "yargs": "^7.0.2"
       },
       "dependencies": {
         "camelcase": {
@@ -9073,8 +9074,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -9082,11 +9083,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           },
           "dependencies": {
             "strip-bom": {
@@ -9094,7 +9095,7 @@
               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
               "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
               "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
               }
             }
           }
@@ -9104,7 +9105,7 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
-            "lcid": "1.0.0"
+            "lcid": "^1.0.0"
           }
         },
         "path-exists": {
@@ -9112,7 +9113,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -9120,9 +9121,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -9135,9 +9136,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -9145,8 +9146,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "which-module": {
@@ -9159,19 +9160,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "5.0.0"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^5.0.0"
           }
         },
         "yargs-parser": {
@@ -9179,7 +9180,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
           "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
           "requires": {
-            "camelcase": "3.0.0"
+            "camelcase": "^3.0.0"
           }
         }
       }
@@ -9189,12 +9190,12 @@
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-20.0.3.tgz",
       "integrity": "sha1-W4R+GtsaTZCFKn+fElCG4YfHZWY=",
       "requires": {
-        "chalk": "1.1.3",
-        "jest-diff": "20.0.3",
-        "jest-matcher-utils": "20.0.3",
-        "jest-util": "20.0.3",
-        "natural-compare": "1.4.0",
-        "pretty-format": "20.0.3"
+        "chalk": "^1.1.3",
+        "jest-diff": "^20.0.3",
+        "jest-matcher-utils": "^20.0.3",
+        "jest-util": "^20.0.3",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^20.0.3"
       }
     },
     "jest-util": {
@@ -9202,13 +9203,13 @@
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-20.0.3.tgz",
       "integrity": "sha1-DAf32A2C9OWmfG+LnD/n9lz9Mq0=",
       "requires": {
-        "chalk": "1.1.3",
-        "graceful-fs": "4.1.11",
-        "jest-message-util": "20.0.3",
-        "jest-mock": "20.0.3",
-        "jest-validate": "20.0.3",
-        "leven": "2.1.0",
-        "mkdirp": "0.5.1"
+        "chalk": "^1.1.3",
+        "graceful-fs": "^4.1.11",
+        "jest-message-util": "^20.0.3",
+        "jest-mock": "^20.0.3",
+        "jest-validate": "^20.0.3",
+        "leven": "^2.1.0",
+        "mkdirp": "^0.5.1"
       }
     },
     "jest-validate": {
@@ -9216,10 +9217,10 @@
       "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-20.0.3.tgz",
       "integrity": "sha1-0M/R3k9XnymEhJJcKA+PHZTsPKs=",
       "requires": {
-        "chalk": "1.1.3",
-        "jest-matcher-utils": "20.0.3",
-        "leven": "2.1.0",
-        "pretty-format": "20.0.3"
+        "chalk": "^1.1.3",
+        "jest-matcher-utils": "^20.0.3",
+        "leven": "^2.1.0",
+        "pretty-format": "^20.0.3"
       }
     },
     "joi": {
@@ -9227,9 +9228,9 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-13.2.0.tgz",
       "integrity": "sha512-VUzQwyCrmT2lIpxBCYq26dcK9veCQzDh84gQnCtaxCa8ePohX8JZVVsIb+E66kCUUcIvzeIpifa6eZuzqTZ3NA==",
       "requires": {
-        "hoek": "5.0.3",
-        "isemail": "3.1.2",
-        "topo": "3.0.0"
+        "hoek": "5.x.x",
+        "isemail": "3.x.x",
+        "topo": "3.x.x"
       },
       "dependencies": {
         "hoek": {
@@ -9242,7 +9243,7 @@
           "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.2.tgz",
           "integrity": "sha512-zfRhJn9rFSGhzU5tGZqepRSAj3+g6oTOHxMGGriWNJZzyLPUK8H7VHpqKntegnW8KLyGA9zwuNaCoopl40LTpg==",
           "requires": {
-            "punycode": "2.1.0"
+            "punycode": "2.x.x"
           }
         },
         "topo": {
@@ -9250,7 +9251,7 @@
           "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
           "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
           "requires": {
-            "hoek": "5.0.3"
+            "hoek": "5.x.x"
           }
         }
       }
@@ -9265,8 +9266,8 @@
       "resolved": "https://registry.npmjs.org/joi-multiaddr/-/joi-multiaddr-1.0.1.tgz",
       "integrity": "sha512-Ye5bCPQZ3Jl8zSaiBwKjBiZf3dM9PIrvWizrOecwRlbWpGWt0kPK5PunOMm/nAdVIOwQIR1Z2/sGMe3u+vrCGA==",
       "requires": {
-        "mafmt": "4.0.0",
-        "multiaddr": "3.1.0"
+        "mafmt": "^4.0.0",
+        "multiaddr": "^3.0.2"
       }
     },
     "js-base64": {
@@ -9289,8 +9290,8 @@
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "2.7.3"
+        "argparse": "^1.0.7",
+        "esprima": "^2.6.0"
       }
     },
     "jsbn": {
@@ -9309,25 +9310,25 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
       "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
       "requires": {
-        "abab": "1.0.4",
-        "acorn": "4.0.13",
-        "acorn-globals": "3.1.0",
-        "array-equal": "1.0.0",
-        "content-type-parser": "1.0.1",
-        "cssom": "0.3.2",
-        "cssstyle": "0.2.37",
-        "escodegen": "1.9.0",
-        "html-encoding-sniffer": "1.0.1",
-        "nwmatcher": "1.4.2",
-        "parse5": "1.5.1",
-        "request": "2.83.0",
-        "sax": "1.2.4",
-        "symbol-tree": "3.2.2",
-        "tough-cookie": "2.3.3",
-        "webidl-conversions": "4.0.2",
-        "whatwg-encoding": "1.0.1",
-        "whatwg-url": "4.8.0",
-        "xml-name-validator": "2.0.1"
+        "abab": "^1.0.3",
+        "acorn": "^4.0.4",
+        "acorn-globals": "^3.1.0",
+        "array-equal": "^1.0.0",
+        "content-type-parser": "^1.0.1",
+        "cssom": ">= 0.3.2 < 0.4.0",
+        "cssstyle": ">= 0.2.37 < 0.3.0",
+        "escodegen": "^1.6.1",
+        "html-encoding-sniffer": "^1.0.1",
+        "nwmatcher": ">= 1.3.9 < 2.0.0",
+        "parse5": "^1.5.1",
+        "request": "^2.79.0",
+        "sax": "^1.2.1",
+        "symbol-tree": "^3.2.1",
+        "tough-cookie": "^2.3.2",
+        "webidl-conversions": "^4.0.0",
+        "whatwg-encoding": "^1.0.1",
+        "whatwg-url": "^4.3.0",
+        "xml-name-validator": "^2.0.1"
       },
       "dependencies": {
         "acorn": {
@@ -9372,7 +9373,7 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -9403,7 +9404,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
       "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsonify": {
@@ -9432,9 +9433,9 @@
       "resolved": "https://registry.npmjs.org/k-bucket/-/k-bucket-3.3.1.tgz",
       "integrity": "sha512-kgwWqYT79rAahn4maIVTP8dIe+m1KulufWW+f1bB9DlZrRFiGpZ4iJOg2HUp4xJYBWONP3+rOPIWF/RXABU6mw==",
       "requires": {
-        "buffer-equals": "1.0.4",
-        "inherits": "2.0.3",
-        "randombytes": "2.0.5"
+        "buffer-equals": "^1.0.3",
+        "inherits": "^2.0.1",
+        "randombytes": "^2.0.3"
       }
     },
     "katex": {
@@ -9442,7 +9443,7 @@
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.9.0.tgz",
       "integrity": "sha512-lp3x90LT1tDZBW2tjLheJ98wmRMRjUHwk4QpaswT9bhqoQZ+XA4cPcjcQBxgOQNwaOSt6ZeL/a6GKQ1of3LFxQ==",
       "requires": {
-        "match-at": "0.1.1"
+        "match-at": "^0.1.1"
       }
     },
     "kebab-case": {
@@ -9455,10 +9456,10 @@
       "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
       "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
       "requires": {
-        "bindings": "1.3.0",
-        "inherits": "2.0.3",
-        "nan": "2.7.0",
-        "safe-buffer": "5.1.1"
+        "bindings": "^1.2.1",
+        "inherits": "^2.0.3",
+        "nan": "^2.2.1",
+        "safe-buffer": "^5.1.0"
       }
     },
     "keccakjs": {
@@ -9466,8 +9467,8 @@
       "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.1.tgz",
       "integrity": "sha1-HWM6+QfvMFu/ny+mFtVsRFYd+k0=",
       "requires": {
-        "browserify-sha3": "0.0.1",
-        "sha3": "1.2.2"
+        "browserify-sha3": "^0.0.1",
+        "sha3": "^1.1.0"
       }
     },
     "keypair": {
@@ -9480,7 +9481,7 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "^1.1.5"
       }
     },
     "klaw": {
@@ -9488,7 +9489,7 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       }
     },
     "latest-version": {
@@ -9496,7 +9497,7 @@
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "requires": {
-        "package-json": "4.0.1"
+        "package-json": "^4.0.0"
       }
     },
     "lazy-cache": {
@@ -9514,7 +9515,7 @@
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "left-pad": {
@@ -9527,9 +9528,9 @@
       "resolved": "https://registry.npmjs.org/length-prefixed-stream/-/length-prefixed-stream-1.5.2.tgz",
       "integrity": "sha512-5kHV/7ZCefC27d4FQLgFHek/pN1S0uEQ8OEgSm55DWO1rKxGi9by4F444aStxa56wB20b6CxZw6KiGPwmJOUmQ==",
       "requires": {
-        "buffer-alloc-unsafe": "1.0.0",
-        "readable-stream": "2.3.3",
-        "varint": "5.0.0"
+        "buffer-alloc-unsafe": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "varint": "^5.0.0"
       },
       "dependencies": {
         "buffer-alloc-unsafe": {
@@ -9549,7 +9550,7 @@
       "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
       "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
       "requires": {
-        "errno": "0.1.4"
+        "errno": "~0.1.1"
       }
     },
     "level-iterator-stream": {
@@ -9557,10 +9558,10 @@
       "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
       "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
       "requires": {
-        "inherits": "2.0.3",
-        "level-errors": "1.0.5",
-        "readable-stream": "1.1.14",
-        "xtend": "4.0.1"
+        "inherits": "^2.0.1",
+        "level-errors": "^1.0.3",
+        "readable-stream": "^1.0.33",
+        "xtend": "^4.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -9573,10 +9574,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -9588,11 +9589,12 @@
     },
     "level-js": {
       "version": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
+      "from": "level-js@github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
       "requires": {
-        "abstract-leveldown": "2.4.1",
+        "abstract-leveldown": "~2.4.1",
         "idb-readable-stream": "0.0.4",
-        "ltgt": "2.2.1",
-        "xtend": "4.0.1"
+        "ltgt": "^2.1.2",
+        "xtend": "^4.0.1"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -9600,7 +9602,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.4.1.tgz",
           "integrity": "sha1-s7/tuITraToSd18MVenwpCDM7mQ=",
           "requires": {
-            "xtend": "4.0.1"
+            "xtend": "~4.0.0"
           }
         }
       }
@@ -9610,8 +9612,8 @@
       "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
       "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
       "requires": {
-        "readable-stream": "1.0.34",
-        "xtend": "2.1.2"
+        "readable-stream": "~1.0.15",
+        "xtend": "~2.1.1"
       },
       "dependencies": {
         "isarray": {
@@ -9629,10 +9631,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -9645,7 +9647,7 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "requires": {
-            "object-keys": "0.4.0"
+            "object-keys": "~0.4.0"
           }
         }
       }
@@ -9655,11 +9657,11 @@
       "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.9.0.tgz",
       "integrity": "sha512-3MwcrnCUIuFiKp/jSrG1UqDTV4k1yH8f5HH6T9dpqCKG+lRxcfo2KwAqbzTT+TTKfCbaATeHMy9mm1y6sI3ZvA==",
       "requires": {
-        "abstract-leveldown": "2.7.2",
-        "bindings": "1.3.0",
-        "fast-future": "1.0.2",
-        "nan": "2.7.0",
-        "prebuild-install": "2.5.3"
+        "abstract-leveldown": "~2.7.0",
+        "bindings": "~1.3.0",
+        "fast-future": "~1.0.2",
+        "nan": "~2.7.0",
+        "prebuild-install": "^2.1.0"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -9667,7 +9669,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
           "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
           "requires": {
-            "xtend": "4.0.1"
+            "xtend": "~4.0.0"
           }
         }
       }
@@ -9677,13 +9679,13 @@
       "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
       "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
       "requires": {
-        "deferred-leveldown": "1.2.2",
-        "level-codec": "7.0.1",
-        "level-errors": "1.0.5",
-        "level-iterator-stream": "1.3.1",
-        "prr": "1.0.1",
-        "semver": "5.4.1",
-        "xtend": "4.0.1"
+        "deferred-leveldown": "~1.2.1",
+        "level-codec": "~7.0.0",
+        "level-errors": "~1.0.3",
+        "level-iterator-stream": "~1.3.0",
+        "prr": "~1.0.1",
+        "semver": "~5.4.1",
+        "xtend": "~4.0.0"
       }
     },
     "leven": {
@@ -9696,8 +9698,8 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "libp2p": {
@@ -9705,15 +9707,15 @@
       "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.18.0.tgz",
       "integrity": "sha512-gC5TNB3atM5Tc14CFu14IEAqm/v9ZJA3XuCX+kbZfcTZiNbMiIFTZrQY4UY/0mx7ZEpDTJn/fGwI8OIc0EYJRQ==",
       "requires": {
-        "async": "2.6.0",
-        "libp2p-floodsub": "0.14.1",
-        "libp2p-ping": "0.6.1",
-        "libp2p-switch": "0.36.1",
-        "mafmt": "4.0.0",
-        "multiaddr": "3.1.0",
-        "peer-book": "0.5.4",
-        "peer-id": "0.10.7",
-        "peer-info": "0.11.6"
+        "async": "^2.6.0",
+        "libp2p-floodsub": "^0.14.1",
+        "libp2p-ping": "~0.6.1",
+        "libp2p-switch": "~0.36.1",
+        "mafmt": "^4.0.0",
+        "multiaddr": "^3.0.2",
+        "peer-book": "~0.5.4",
+        "peer-id": "~0.10.6",
+        "peer-info": "~0.11.6"
       },
       "dependencies": {
         "async": {
@@ -9721,7 +9723,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         }
       }
@@ -9731,22 +9733,22 @@
       "resolved": "https://registry.npmjs.org/libp2p-circuit/-/libp2p-circuit-0.1.5.tgz",
       "integrity": "sha512-0aUhyceJjpmB+lo0InYuzLP5NPWjkdga8LoZ0Gw1Qm+ghPOXk/plPBUH4urLT84H10aPb/OETyG9i1+uQQPxFA==",
       "requires": {
-        "assert": "1.4.1",
-        "async": "2.6.0",
-        "debug": "3.1.0",
-        "interface-connection": "0.3.2",
-        "lodash": "4.17.10",
-        "mafmt": "4.0.0",
-        "multiaddr": "3.1.0",
-        "multistream-select": "0.14.2",
-        "peer-id": "0.10.7",
-        "peer-info": "0.11.6",
-        "protons": "1.0.1",
-        "pull-abortable": "4.1.1",
-        "pull-handshake": "1.1.4",
-        "pull-stream": "3.6.7",
-        "safe-buffer": "5.1.1",
-        "setimmediate": "1.0.5"
+        "assert": "^1.4.1",
+        "async": "^2.6.0",
+        "debug": "^3.1.0",
+        "interface-connection": "^0.3.2",
+        "lodash": "^4.17.5",
+        "mafmt": "^4.0.0",
+        "multiaddr": "^3.0.2",
+        "multistream-select": "^0.14.1",
+        "peer-id": "^0.10.6",
+        "peer-info": "^0.11.6",
+        "protons": "^1.0.1",
+        "pull-abortable": "^4.1.1",
+        "pull-handshake": "^1.1.4",
+        "pull-stream": "^3.6.2",
+        "safe-buffer": "^5.1.1",
+        "setimmediate": "^1.0.5"
       },
       "dependencies": {
         "async": {
@@ -9754,7 +9756,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.10"
+            "lodash": "^4.14.0"
           }
         },
         "lodash": {
@@ -9769,16 +9771,16 @@
       "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.10.4.tgz",
       "integrity": "sha512-jNEs0/LouDqMGEE9hN1yRfkeFtDrgMbEGPy5xE/y2OVWr9WFU5S/u/tlpF3aeT0b/xhy/zCtSZ/PjzviJwuv5w==",
       "requires": {
-        "asn1.js": "5.0.0",
-        "async": "2.6.0",
-        "browserify-aes": "1.2.0",
-        "keypair": "1.0.1",
-        "libp2p-crypto-secp256k1": "0.2.2",
-        "multihashing-async": "0.4.8",
-        "pem-jwk": "1.5.1",
-        "protons": "1.0.1",
-        "rsa-pem-to-jwk": "1.1.3",
-        "tweetnacl": "1.0.0",
+        "asn1.js": "^5.0.0",
+        "async": "^2.6.0",
+        "browserify-aes": "^1.1.1",
+        "keypair": "^1.0.1",
+        "libp2p-crypto-secp256k1": "~0.2.2",
+        "multihashing-async": "~0.4.7",
+        "pem-jwk": "^1.5.1",
+        "protons": "^1.0.0",
+        "rsa-pem-to-jwk": "^1.1.3",
+        "tweetnacl": "^1.0.0",
         "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
       },
       "dependencies": {
@@ -9787,9 +9789,9 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.0.tgz",
           "integrity": "sha512-Y+FKviD0uyIWWo/xE0XkUl0x1allKFhzEVJ+//2Dgqpy+n+B77MlPNqvyk7Vx50M9XyVzjnRhDqJAEAsyivlbA==",
           "requires": {
-            "bn.js": "4.11.8",
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.0"
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "async": {
@@ -9797,7 +9799,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "browserify-aes": {
@@ -9805,12 +9807,12 @@
           "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
           "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
           "requires": {
-            "buffer-xor": "1.0.3",
-            "cipher-base": "1.0.4",
-            "create-hash": "1.1.3",
-            "evp_bytestokey": "1.0.3",
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
+            "buffer-xor": "^1.0.3",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.3",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -9825,11 +9827,11 @@
       "resolved": "https://registry.npmjs.org/libp2p-crypto-secp256k1/-/libp2p-crypto-secp256k1-0.2.2.tgz",
       "integrity": "sha1-DdUh8Yq8TjahUuJOmzYwewrpzwU=",
       "requires": {
-        "async": "2.5.0",
-        "multihashing-async": "0.4.8",
-        "nodeify": "1.0.1",
-        "safe-buffer": "5.1.1",
-        "secp256k1": "3.5.0"
+        "async": "^2.5.0",
+        "multihashing-async": "~0.4.6",
+        "nodeify": "^1.0.1",
+        "safe-buffer": "^5.1.1",
+        "secp256k1": "^3.3.0"
       }
     },
     "libp2p-floodsub": {
@@ -9837,15 +9839,15 @@
       "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.14.1.tgz",
       "integrity": "sha512-MxdKgD/1dWlQjT4WVlirAHq0QAczGjC/P0SLpoYRna/RZqEmkOuiJfUEwqWWZXENVBuyQep8Ry3yLKt67xJfVg==",
       "requires": {
-        "async": "2.6.0",
-        "bs58": "4.0.1",
-        "debug": "3.1.0",
-        "length-prefixed-stream": "1.5.2",
-        "libp2p-crypto": "0.12.1",
-        "lodash.values": "4.3.0",
-        "protons": "1.0.1",
-        "pull-pushable": "2.2.0",
-        "time-cache": "0.3.0"
+        "async": "^2.6.0",
+        "bs58": "^4.0.1",
+        "debug": "^3.1.0",
+        "length-prefixed-stream": "^1.5.1",
+        "libp2p-crypto": "~0.12.1",
+        "lodash.values": "^4.3.0",
+        "protons": "^1.0.1",
+        "pull-pushable": "^2.1.2",
+        "time-cache": "~0.3.0"
       },
       "dependencies": {
         "asn1.js": {
@@ -9853,9 +9855,9 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.0.tgz",
           "integrity": "sha512-Y+FKviD0uyIWWo/xE0XkUl0x1allKFhzEVJ+//2Dgqpy+n+B77MlPNqvyk7Vx50M9XyVzjnRhDqJAEAsyivlbA==",
           "requires": {
-            "bn.js": "4.11.8",
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.0"
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "async": {
@@ -9863,7 +9865,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "browserify-aes": {
@@ -9871,12 +9873,12 @@
           "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
           "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
           "requires": {
-            "buffer-xor": "1.0.3",
-            "cipher-base": "1.0.4",
-            "create-hash": "1.1.3",
-            "evp_bytestokey": "1.0.3",
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
+            "buffer-xor": "^1.0.3",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.3",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "libp2p-crypto": {
@@ -9884,18 +9886,18 @@
           "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
           "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
           "requires": {
-            "asn1.js": "5.0.0",
-            "async": "2.6.0",
-            "browserify-aes": "1.2.0",
-            "bs58": "4.0.1",
-            "keypair": "1.0.1",
-            "libp2p-crypto-secp256k1": "0.2.2",
-            "multihashing-async": "0.4.8",
-            "node-forge": "0.7.5",
-            "pem-jwk": "1.5.1",
-            "protons": "1.0.1",
-            "rsa-pem-to-jwk": "1.1.3",
-            "tweetnacl": "1.0.0",
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.1.1",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.7",
+            "node-forge": "^0.7.1",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
             "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           }
         },
@@ -9916,12 +9918,12 @@
       "resolved": "https://registry.npmjs.org/libp2p-identify/-/libp2p-identify-0.6.3.tgz",
       "integrity": "sha512-tCkobHxmK636lCF3PwIA/G8Ty7KGFVT/WW7zaNUUypMKJKT9gZg9U1d+BVTM2xA4TUYSnt8TTY6WgKeUfDffHg==",
       "requires": {
-        "multiaddr": "3.1.0",
-        "peer-id": "0.10.7",
-        "peer-info": "0.11.6",
-        "protons": "1.0.1",
-        "pull-length-prefixed": "1.3.0",
-        "pull-stream": "3.6.7"
+        "multiaddr": "^3.0.2",
+        "peer-id": "~0.10.5",
+        "peer-info": "~0.11.6",
+        "protons": "^1.0.1",
+        "pull-length-prefixed": "^1.3.0",
+        "pull-stream": "^3.6.1"
       }
     },
     "libp2p-kad-dht": {
@@ -9929,26 +9931,26 @@
       "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.8.0.tgz",
       "integrity": "sha512-eVpOFz2nvAG/zcusWSU2uBQFyD+jbmDIXOtdAlYDJiwKvXkfZ3wWmzmePEaM+vzr/zI2srtWH0WeMMJkR7HgkQ==",
       "requires": {
-        "async": "2.6.0",
-        "base32.js": "0.1.0",
-        "cids": "0.5.3",
-        "debug": "3.1.0",
-        "hashlru": "2.2.1",
-        "heap": "0.2.6",
-        "interface-datastore": "0.4.2",
-        "k-bucket": "3.3.1",
-        "libp2p-crypto": "0.12.1",
-        "libp2p-record": "0.5.1",
-        "multihashing-async": "0.4.8",
-        "peer-id": "0.10.7",
-        "peer-info": "0.11.6",
-        "priorityqueue": "0.2.1",
-        "protons": "1.0.1",
-        "pull-length-prefixed": "1.3.0",
-        "pull-stream": "3.6.7",
-        "safe-buffer": "5.1.1",
-        "varint": "5.0.0",
-        "xor-distance": "1.0.0"
+        "async": "^2.6.0",
+        "base32.js": "^0.1.0",
+        "cids": "~0.5.2",
+        "debug": "^3.1.0",
+        "hashlru": "^2.2.1",
+        "heap": "^0.2.6",
+        "interface-datastore": "~0.4.2",
+        "k-bucket": "^3.3.1",
+        "libp2p-crypto": "~0.12.0",
+        "libp2p-record": "~0.5.1",
+        "multihashing-async": "~0.4.7",
+        "peer-id": "~0.10.5",
+        "peer-info": "~0.11.6",
+        "priorityqueue": "^0.2.0",
+        "protons": "^1.0.1",
+        "pull-length-prefixed": "^1.3.0",
+        "pull-stream": "^3.6.1",
+        "safe-buffer": "^5.1.1",
+        "varint": "^5.0.0",
+        "xor-distance": "^1.0.0"
       },
       "dependencies": {
         "asn1.js": {
@@ -9956,9 +9958,9 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.0.tgz",
           "integrity": "sha512-Y+FKviD0uyIWWo/xE0XkUl0x1allKFhzEVJ+//2Dgqpy+n+B77MlPNqvyk7Vx50M9XyVzjnRhDqJAEAsyivlbA==",
           "requires": {
-            "bn.js": "4.11.8",
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.0"
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "async": {
@@ -9966,7 +9968,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "browserify-aes": {
@@ -9974,12 +9976,12 @@
           "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
           "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
           "requires": {
-            "buffer-xor": "1.0.3",
-            "cipher-base": "1.0.4",
-            "create-hash": "1.1.3",
-            "evp_bytestokey": "1.0.3",
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
+            "buffer-xor": "^1.0.3",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.3",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "libp2p-crypto": {
@@ -9987,18 +9989,18 @@
           "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
           "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
           "requires": {
-            "asn1.js": "5.0.0",
-            "async": "2.6.0",
-            "browserify-aes": "1.2.0",
-            "bs58": "4.0.1",
-            "keypair": "1.0.1",
-            "libp2p-crypto-secp256k1": "0.2.2",
-            "multihashing-async": "0.4.8",
-            "node-forge": "0.7.5",
-            "pem-jwk": "1.5.1",
-            "protons": "1.0.1",
-            "rsa-pem-to-jwk": "1.1.3",
-            "tweetnacl": "1.0.0",
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.1.1",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.7",
+            "node-forge": "^0.7.1",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
             "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           }
         },
@@ -10019,12 +10021,12 @@
       "resolved": "https://registry.npmjs.org/libp2p-keychain/-/libp2p-keychain-0.3.1.tgz",
       "integrity": "sha512-dsKw+gP/P7wDPkDpQZVVU+mRUlPqEmcYxGhvrEyjd7+UdcTxydEFbwvP0HQLVkkoLjsr2dVSauh7FdX7ZUmnQQ==",
       "requires": {
-        "async": "2.6.0",
-        "deepmerge": "1.5.2",
-        "interface-datastore": "0.4.2",
-        "libp2p-crypto": "0.12.1",
-        "pull-stream": "3.6.7",
-        "sanitize-filename": "1.6.1"
+        "async": "^2.6.0",
+        "deepmerge": "^1.5.2",
+        "interface-datastore": "~0.4.2",
+        "libp2p-crypto": "~0.12.0",
+        "pull-stream": "^3.6.1",
+        "sanitize-filename": "^1.6.1"
       },
       "dependencies": {
         "asn1.js": {
@@ -10032,9 +10034,9 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.0.tgz",
           "integrity": "sha512-Y+FKviD0uyIWWo/xE0XkUl0x1allKFhzEVJ+//2Dgqpy+n+B77MlPNqvyk7Vx50M9XyVzjnRhDqJAEAsyivlbA==",
           "requires": {
-            "bn.js": "4.11.8",
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.0"
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "async": {
@@ -10042,7 +10044,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "browserify-aes": {
@@ -10050,12 +10052,12 @@
           "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
           "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
           "requires": {
-            "buffer-xor": "1.0.3",
-            "cipher-base": "1.0.4",
-            "create-hash": "1.1.3",
-            "evp_bytestokey": "1.0.3",
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
+            "buffer-xor": "^1.0.3",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.3",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "libp2p-crypto": {
@@ -10063,18 +10065,18 @@
           "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
           "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
           "requires": {
-            "asn1.js": "5.0.0",
-            "async": "2.6.0",
-            "browserify-aes": "1.2.0",
-            "bs58": "4.0.1",
-            "keypair": "1.0.1",
-            "libp2p-crypto-secp256k1": "0.2.2",
-            "multihashing-async": "0.4.8",
-            "node-forge": "0.7.5",
-            "pem-jwk": "1.5.1",
-            "protons": "1.0.1",
-            "rsa-pem-to-jwk": "1.1.3",
-            "tweetnacl": "1.0.0",
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.1.1",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.7",
+            "node-forge": "^0.7.1",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
             "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           }
         },
@@ -10095,11 +10097,11 @@
       "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.9.2.tgz",
       "integrity": "sha512-g77yK3znf4bZl6466EOs1MGP9Pqv4gEcsCnuDaSiWtZ4bZOApkGS/gWQBY3vaCbP1faJ5m7b83uBlEeHiT61cA==",
       "requires": {
-        "libp2p-tcp": "0.11.6",
-        "multiaddr": "3.1.0",
-        "multicast-dns": "6.2.3",
-        "peer-id": "0.10.7",
-        "peer-info": "0.11.6"
+        "libp2p-tcp": "~0.11.2",
+        "multiaddr": "^3.0.2",
+        "multicast-dns": "^6.2.3",
+        "peer-id": "~0.10.5",
+        "peer-info": "~0.11.6"
       },
       "dependencies": {
         "dns-packet": {
@@ -10107,8 +10109,8 @@
           "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
           "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
           "requires": {
-            "ip": "1.1.5",
-            "safe-buffer": "5.1.1"
+            "ip": "^1.1.0",
+            "safe-buffer": "^5.0.1"
           }
         },
         "multicast-dns": {
@@ -10116,8 +10118,8 @@
           "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
           "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
           "requires": {
-            "dns-packet": "1.3.1",
-            "thunky": "1.0.2"
+            "dns-packet": "^1.3.1",
+            "thunky": "^1.0.2"
           }
         },
         "thunky": {
@@ -10132,13 +10134,13 @@
       "resolved": "https://registry.npmjs.org/libp2p-multiplex/-/libp2p-multiplex-0.5.1.tgz",
       "integrity": "sha512-XZagf1B31Vkbd+iAai8cOfRkcZWba+MtSRf/xQJ7uOz7O4heLMNC4orcDqT0n+Hkkn3zfqllH75Kp1xJ+Vog2w==",
       "requires": {
-        "async": "2.6.0",
+        "async": "^2.6.0",
         "multiplex": "github:dignifiedquire/multiplex#b5d5edd30454e2c978ee8c52df86f5f4840d2eab",
-        "pull-catch": "1.0.0",
-        "pull-stream": "3.6.7",
-        "pull-stream-to-stream": "1.3.4",
-        "pump": "2.0.1",
-        "stream-to-pull-stream": "1.7.2"
+        "pull-catch": "^1.0.0",
+        "pull-stream": "^3.6.1",
+        "pull-stream-to-stream": "^1.3.4",
+        "pump": "^2.0.0",
+        "stream-to-pull-stream": "^1.7.2"
       },
       "dependencies": {
         "async": {
@@ -10146,7 +10148,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "pump": {
@@ -10154,8 +10156,8 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "requires": {
-            "end-of-stream": "1.4.0",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         }
       }
@@ -10165,9 +10167,9 @@
       "resolved": "https://registry.npmjs.org/libp2p-ping/-/libp2p-ping-0.6.1.tgz",
       "integrity": "sha512-1u+77pedHwEqGp4LELBsYtjXrZSmXMGoPpfNAXLq0jyai4F54rvDAMin78VQlYbvNB2oz10KrOD34IlV3Cna1w==",
       "requires": {
-        "libp2p-crypto": "0.12.1",
-        "pull-handshake": "1.1.4",
-        "pull-stream": "3.6.7"
+        "libp2p-crypto": "~0.12.1",
+        "pull-handshake": "^1.1.4",
+        "pull-stream": "^3.6.1"
       },
       "dependencies": {
         "asn1.js": {
@@ -10175,9 +10177,9 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.0.tgz",
           "integrity": "sha512-Y+FKviD0uyIWWo/xE0XkUl0x1allKFhzEVJ+//2Dgqpy+n+B77MlPNqvyk7Vx50M9XyVzjnRhDqJAEAsyivlbA==",
           "requires": {
-            "bn.js": "4.11.8",
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.0"
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "async": {
@@ -10185,7 +10187,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "browserify-aes": {
@@ -10193,12 +10195,12 @@
           "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
           "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
           "requires": {
-            "buffer-xor": "1.0.3",
-            "cipher-base": "1.0.4",
-            "create-hash": "1.1.3",
-            "evp_bytestokey": "1.0.3",
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
+            "buffer-xor": "^1.0.3",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.3",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "libp2p-crypto": {
@@ -10206,18 +10208,18 @@
           "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
           "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
           "requires": {
-            "asn1.js": "5.0.0",
-            "async": "2.6.0",
-            "browserify-aes": "1.2.0",
-            "bs58": "4.0.1",
-            "keypair": "1.0.1",
-            "libp2p-crypto-secp256k1": "0.2.2",
-            "multihashing-async": "0.4.8",
-            "node-forge": "0.7.5",
-            "pem-jwk": "1.5.1",
-            "protons": "1.0.1",
-            "rsa-pem-to-jwk": "1.1.3",
-            "tweetnacl": "1.0.0",
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.1.1",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.7",
+            "node-forge": "^0.7.1",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
             "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           }
         },
@@ -10238,12 +10240,12 @@
       "resolved": "https://registry.npmjs.org/libp2p-railing/-/libp2p-railing-0.7.1.tgz",
       "integrity": "sha512-IrmBwIhaXpeTMCSoJTTtUPUumO/tQdTV9cmc98rEm+dgJ9Lfl7LgOMQWUdBAcqUC2mrFmBElAphV19DR7jYU1g==",
       "requires": {
-        "async": "2.5.0",
-        "debug": "3.1.0",
-        "lodash": "4.17.4",
-        "multiaddr": "3.1.0",
-        "peer-id": "0.10.7",
-        "peer-info": "0.11.6"
+        "async": "^2.5.0",
+        "debug": "^3.0.1",
+        "lodash": "^4.17.4",
+        "multiaddr": "^3.0.1",
+        "peer-id": "~0.10.1",
+        "peer-info": "~0.11.0"
       }
     },
     "libp2p-record": {
@@ -10251,13 +10253,13 @@
       "resolved": "https://registry.npmjs.org/libp2p-record/-/libp2p-record-0.5.1.tgz",
       "integrity": "sha512-e2qLv0Tx4yBrGQrTbogWKpRFAM5rhmwTAnm/IfVn8/TzRBcB4F0PTVRB/Wf0eFCa8dNmD6vTn9wyhe+zmcI1zQ==",
       "requires": {
-        "async": "2.5.0",
-        "buffer-split": "1.0.0",
-        "left-pad": "1.3.0",
-        "multihashes": "0.4.13",
-        "multihashing-async": "0.4.8",
-        "peer-id": "0.10.7",
-        "protons": "1.0.1"
+        "async": "^2.5.0",
+        "buffer-split": "^1.0.0",
+        "left-pad": "^1.1.3",
+        "multihashes": "~0.4.9",
+        "multihashing-async": "~0.4.6",
+        "peer-id": "~0.10.0",
+        "protons": "^1.0.0"
       }
     },
     "libp2p-secio": {
@@ -10265,18 +10267,18 @@
       "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.9.4.tgz",
       "integrity": "sha512-tbeOi5pk+eSTrOmE8dB/3cEaNATAkpOktwTKGuY72azBepcJWW2d9etAUTJMUGM6GAcf8kqenI8ZarcCz6Eydg==",
       "requires": {
-        "async": "2.6.0",
-        "debug": "3.1.0",
-        "interface-connection": "0.3.2",
-        "libp2p-crypto": "0.12.1",
-        "multihashing-async": "0.4.8",
-        "peer-id": "0.10.7",
-        "peer-info": "0.11.6",
-        "protons": "1.0.1",
-        "pull-defer": "0.2.2",
-        "pull-handshake": "1.1.4",
-        "pull-length-prefixed": "1.3.0",
-        "pull-stream": "3.6.7"
+        "async": "^2.6.0",
+        "debug": "^3.1.0",
+        "interface-connection": "~0.3.2",
+        "libp2p-crypto": "~0.12.1",
+        "multihashing-async": "~0.4.8",
+        "peer-id": "~0.10.6",
+        "peer-info": "^0.11.6",
+        "protons": "^1.0.1",
+        "pull-defer": "^0.2.2",
+        "pull-handshake": "^1.1.4",
+        "pull-length-prefixed": "^1.3.0",
+        "pull-stream": "^3.6.7"
       },
       "dependencies": {
         "asn1.js": {
@@ -10284,9 +10286,9 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.0.tgz",
           "integrity": "sha512-Y+FKviD0uyIWWo/xE0XkUl0x1allKFhzEVJ+//2Dgqpy+n+B77MlPNqvyk7Vx50M9XyVzjnRhDqJAEAsyivlbA==",
           "requires": {
-            "bn.js": "4.11.8",
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.0"
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "async": {
@@ -10294,7 +10296,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "browserify-aes": {
@@ -10302,12 +10304,12 @@
           "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
           "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
           "requires": {
-            "buffer-xor": "1.0.3",
-            "cipher-base": "1.0.4",
-            "create-hash": "1.1.3",
-            "evp_bytestokey": "1.0.3",
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
+            "buffer-xor": "^1.0.3",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.3",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "libp2p-crypto": {
@@ -10315,18 +10317,18 @@
           "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
           "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
           "requires": {
-            "asn1.js": "5.0.0",
-            "async": "2.6.0",
-            "browserify-aes": "1.2.0",
-            "bs58": "4.0.1",
-            "keypair": "1.0.1",
-            "libp2p-crypto-secp256k1": "0.2.2",
-            "multihashing-async": "0.4.8",
-            "node-forge": "0.7.5",
-            "pem-jwk": "1.5.1",
-            "protons": "1.0.1",
-            "rsa-pem-to-jwk": "1.1.3",
-            "tweetnacl": "1.0.0",
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.1.1",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.7",
+            "node-forge": "^0.7.1",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
             "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           }
         },
@@ -10347,19 +10349,19 @@
       "resolved": "https://registry.npmjs.org/libp2p-switch/-/libp2p-switch-0.36.1.tgz",
       "integrity": "sha512-rVlxKQJ0h5W7T2ugpwyE8KaCUZJ9lLJVxwCCMV3tkc6ziF0L/lREIfM731yJS9ubdUyRFTgn6F2RlgcTwqfd4A==",
       "requires": {
-        "async": "2.6.0",
-        "debug": "3.1.0",
-        "interface-connection": "0.3.2",
-        "ip-address": "5.8.9",
-        "libp2p-circuit": "0.1.5",
-        "libp2p-identify": "0.6.3",
-        "lodash.includes": "4.3.0",
-        "multiaddr": "3.1.0",
-        "multistream-select": "0.14.2",
-        "once": "1.4.0",
-        "peer-id": "0.10.7",
-        "peer-info": "0.11.6",
-        "pull-stream": "3.6.7"
+        "async": "^2.6.0",
+        "debug": "^3.1.0",
+        "interface-connection": "~0.3.2",
+        "ip-address": "^5.8.9",
+        "libp2p-circuit": "~0.1.4",
+        "libp2p-identify": "~0.6.3",
+        "lodash.includes": "^4.3.0",
+        "multiaddr": "^3.0.2",
+        "multistream-select": "~0.14.1",
+        "once": "^1.4.0",
+        "peer-id": "~0.10.6",
+        "peer-info": "~0.11.6",
+        "pull-stream": "^3.6.1"
       },
       "dependencies": {
         "async": {
@@ -10367,7 +10369,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         }
       }
@@ -10377,15 +10379,15 @@
       "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.11.6.tgz",
       "integrity": "sha512-ob6wIZRmwJ6X7SIZHxjQvqc3wfl/RFPXXK/C94zFi0tEraGK3bvnKdXtZEpb2kYU4fx9RUPEkHV3PJ37/HNCzA==",
       "requires": {
-        "debug": "3.1.0",
-        "interface-connection": "0.3.2",
-        "ip-address": "5.8.9",
-        "lodash.includes": "4.3.0",
-        "lodash.isfunction": "3.0.9",
-        "mafmt": "4.0.0",
-        "multiaddr": "3.1.0",
-        "once": "1.4.0",
-        "stream-to-pull-stream": "1.7.2"
+        "debug": "^3.1.0",
+        "interface-connection": "~0.3.2",
+        "ip-address": "^5.8.9",
+        "lodash.includes": "^4.3.0",
+        "lodash.isfunction": "^3.0.9",
+        "mafmt": "^4.0.0",
+        "multiaddr": "^3.0.2",
+        "once": "^1.4.0",
+        "stream-to-pull-stream": "^1.7.2"
       }
     },
     "libp2p-webrtc-star": {
@@ -10393,24 +10395,24 @@
       "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.13.4.tgz",
       "integrity": "sha512-ZSSWNf2RDZ9kXFEZmMfgdK+r1j6FIv+NGH5VmbRZsPSZnNnod0jvn2z7X45oq9QqTUOxzKUGkh5FIvlPVMV/yg==",
       "requires": {
-        "async": "2.6.0",
-        "debug": "3.1.0",
-        "detect-node": "2.0.3",
-        "epimetheus": "1.0.55",
-        "hapi": "16.6.3",
-        "inert": "4.2.1",
-        "interface-connection": "0.3.2",
-        "mafmt": "4.0.0",
-        "minimist": "1.2.0",
-        "multiaddr": "3.1.0",
-        "once": "1.4.0",
-        "peer-id": "0.10.7",
-        "peer-info": "0.11.6",
-        "pull-stream": "3.6.7",
-        "simple-peer": "8.5.0",
-        "socket.io": "2.1.0",
-        "socket.io-client": "2.1.0",
-        "stream-to-pull-stream": "1.7.2",
+        "async": "^2.6.0",
+        "debug": "^3.1.0",
+        "detect-node": "^2.0.3",
+        "epimetheus": "^1.0.55",
+        "hapi": "^16.6.2",
+        "inert": "^4.2.1",
+        "interface-connection": "~0.3.2",
+        "mafmt": "^4.0.0",
+        "minimist": "^1.2.0",
+        "multiaddr": "^3.0.2",
+        "once": "^1.4.0",
+        "peer-id": "~0.10.6",
+        "peer-info": "~0.11.6",
+        "pull-stream": "^3.6.2",
+        "simple-peer": "^8.5.0",
+        "socket.io": "^2.0.4",
+        "socket.io-client": "^2.0.4",
+        "stream-to-pull-stream": "^1.7.2",
         "webrtcsupport": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615"
       },
       "dependencies": {
@@ -10419,7 +10421,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         }
       }
@@ -10429,21 +10431,21 @@
       "resolved": "https://registry.npmjs.org/libp2p-websocket-star/-/libp2p-websocket-star-0.7.7.tgz",
       "integrity": "sha512-unAy7kzWdUpCFVsm47B4Gk17E/XuPQo3f1cWMGTSd5AtWqsCNNTOD8dBG58DLY//o4ps511KEsNp/yp70n60AA==",
       "requires": {
-        "async": "2.6.0",
+        "async": "^2.6.0",
         "data-queue": "0.0.3",
-        "debug": "3.1.0",
-        "interface-connection": "0.3.2",
-        "libp2p-crypto": "0.12.1",
-        "mafmt": "4.0.0",
+        "debug": "^3.1.0",
+        "interface-connection": "^0.3.2",
+        "libp2p-crypto": "^0.12.1",
+        "mafmt": "^4.0.0",
         "merge-recursive": "0.0.3",
-        "multiaddr": "3.1.0",
-        "once": "1.4.0",
-        "peer-id": "0.10.7",
-        "peer-info": "0.11.6",
-        "pull-stream": "3.6.7",
-        "socket.io-client": "2.1.0",
-        "socket.io-pull-stream": "0.1.5",
-        "uuid": "3.2.1"
+        "multiaddr": "^3.0.2",
+        "once": "^1.4.0",
+        "peer-id": "^0.10.6",
+        "peer-info": "^0.11.6",
+        "pull-stream": "^3.6.2",
+        "socket.io-client": "^2.0.4",
+        "socket.io-pull-stream": "^0.1.4",
+        "uuid": "^3.2.1"
       },
       "dependencies": {
         "asn1.js": {
@@ -10451,9 +10453,9 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.0.tgz",
           "integrity": "sha512-Y+FKviD0uyIWWo/xE0XkUl0x1allKFhzEVJ+//2Dgqpy+n+B77MlPNqvyk7Vx50M9XyVzjnRhDqJAEAsyivlbA==",
           "requires": {
-            "bn.js": "4.11.8",
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.0"
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "async": {
@@ -10461,7 +10463,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "browserify-aes": {
@@ -10469,12 +10471,12 @@
           "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
           "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
           "requires": {
-            "buffer-xor": "1.0.3",
-            "cipher-base": "1.0.4",
-            "create-hash": "1.1.3",
-            "evp_bytestokey": "1.0.3",
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
+            "buffer-xor": "^1.0.3",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.3",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "libp2p-crypto": {
@@ -10482,18 +10484,18 @@
           "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
           "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
           "requires": {
-            "asn1.js": "5.0.0",
-            "async": "2.6.0",
-            "browserify-aes": "1.2.0",
-            "bs58": "4.0.1",
-            "keypair": "1.0.1",
-            "libp2p-crypto-secp256k1": "0.2.2",
-            "multihashing-async": "0.4.8",
-            "node-forge": "0.7.5",
-            "pem-jwk": "1.5.1",
-            "protons": "1.0.1",
-            "rsa-pem-to-jwk": "1.1.3",
-            "tweetnacl": "1.0.0",
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.1.1",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.7",
+            "node-forge": "^0.7.1",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
             "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           }
         },
@@ -10519,10 +10521,10 @@
       "resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.10.5.tgz",
       "integrity": "sha512-umSnkUylBStVtsTJ2v1iWpCCUTFskbSOzUSyZ20mUwfwwPNSd+rmPkisnMRCz64l4UQ8EUs2kp7cS7kExAZODA==",
       "requires": {
-        "interface-connection": "0.3.2",
-        "lodash.includes": "4.3.0",
-        "mafmt": "4.0.0",
-        "pull-ws": "3.3.1"
+        "interface-connection": "~0.3.2",
+        "lodash.includes": "^4.3.0",
+        "mafmt": "^4.0.0",
+        "pull-ws": "^3.3.0"
       }
     },
     "load-json-file": {
@@ -10530,10 +10532,10 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
       },
       "dependencies": {
         "pify": {
@@ -10548,7 +10550,7 @@
       "resolved": "https://registry.npmjs.org/loader-fs-cache/-/loader-fs-cache-1.0.1.tgz",
       "integrity": "sha1-VuC/CL2XCLJqdltoUJhAyN7J/bw=",
       "requires": {
-        "find-cache-dir": "0.1.1",
+        "find-cache-dir": "^0.1.1",
         "mkdirp": "0.5.1"
       },
       "dependencies": {
@@ -10557,9 +10559,9 @@
           "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
           "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "requires": {
-            "commondir": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pkg-dir": "1.0.0"
+            "commondir": "^1.0.1",
+            "mkdirp": "^0.5.1",
+            "pkg-dir": "^1.0.0"
           }
         },
         "find-up": {
@@ -10567,8 +10569,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-exists": {
@@ -10576,7 +10578,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pkg-dir": {
@@ -10584,7 +10586,7 @@
           "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           }
         }
       }
@@ -10599,9 +10601,9 @@
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
       "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1"
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0"
       }
     },
     "locate-path": {
@@ -10609,8 +10611,8 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lock-me": {
@@ -10618,11 +10620,11 @@
       "resolved": "https://registry.npmjs.org/lock-me/-/lock-me-1.0.3.tgz",
       "integrity": "sha512-8Oc/h8ltAtEvq4+qZvqpbopWKEWFmcoI3cVoEWnlVWsoBGihwtw3abO3T4hERswRS0aHY1rIfqnIjo2uBqqlXA==",
       "requires": {
-        "async": "2.5.0",
-        "find-process": "1.1.1",
+        "async": "^2.1.5",
+        "find-process": "^1.0.5",
         "fs-ext": "github:baudehlo/node-fs-ext#500be8514729c194ac7ca2b30b5bc7eaf812670d",
-        "nodeify": "1.0.1",
-        "once": "1.4.0"
+        "nodeify": "^1.0.1",
+        "once": "^1.4.0"
       }
     },
     "lodash": {
@@ -10781,8 +10783,8 @@
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
       "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
       "requires": {
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.templatesettings": "4.1.0"
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
       }
     },
     "lodash.templatesettings": {
@@ -10790,7 +10792,7 @@
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
       "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
       "requires": {
-        "lodash._reinterpolate": "3.0.0"
+        "lodash._reinterpolate": "~3.0.0"
       }
     },
     "lodash.throttle": {
@@ -10843,7 +10845,7 @@
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
     },
     "loud-rejection": {
@@ -10851,8 +10853,8 @@
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lower-case": {
@@ -10870,8 +10872,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "ltgt": {
@@ -10889,7 +10891,7 @@
       "resolved": "https://registry.npmjs.org/mafmt/-/mafmt-4.0.0.tgz",
       "integrity": "sha512-zTqHhC9UUYlOkTwOXkdNqCE5U7vuz5UzlRJa4Et3ddCu/Sq36Z8F9mWCGdoqzahDcnRiGc515XjsnkAQHdH55g==",
       "requires": {
-        "multiaddr": "3.1.0"
+        "multiaddr": "^3.0.2"
       }
     },
     "make-dir": {
@@ -10897,7 +10899,7 @@
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
       "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.3.0"
       },
       "dependencies": {
         "pify": {
@@ -10912,7 +10914,7 @@
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "requires": {
-        "tmpl": "1.0.4"
+        "tmpl": "1.0.x"
       }
     },
     "map-obj": {
@@ -10945,8 +10947,8 @@
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
       },
       "dependencies": {
         "hash-base": {
@@ -10954,8 +10956,8 @@
           "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         }
       }
@@ -10965,8 +10967,8 @@
       "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-1.0.1.tgz",
       "integrity": "sha1-zbX4TitqLTEU3zO9BdnLMuPECDo=",
       "requires": {
-        "unist-util-modify-children": "1.1.2",
-        "unist-util-visit": "1.3.0"
+        "unist-util-modify-children": "^1.0.0",
+        "unist-util-visit": "^1.1.0"
       }
     },
     "mdast-util-definitions": {
@@ -10974,7 +10976,7 @@
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-1.2.2.tgz",
       "integrity": "sha512-9NloPSwaB9f1PKcGqaScfqRf6zKOEjTIXVIbPOmgWI/JKxznlgVXC5C+8qgl3AjYg2vJBRgLYfLICaNiac89iA==",
       "requires": {
-        "unist-util-visit": "1.3.0"
+        "unist-util-visit": "^1.0.0"
       }
     },
     "mdast-util-to-hast": {
@@ -10982,17 +10984,17 @@
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-2.5.0.tgz",
       "integrity": "sha1-8IeETSVcdUDzaQbaMLoQbA7l7i8=",
       "requires": {
-        "collapse-white-space": "1.0.4",
-        "detab": "2.0.1",
-        "mdast-util-definitions": "1.2.2",
-        "mdurl": "1.0.1",
+        "collapse-white-space": "^1.0.0",
+        "detab": "^2.0.0",
+        "mdast-util-definitions": "^1.2.0",
+        "mdurl": "^1.0.1",
         "trim": "0.0.1",
-        "trim-lines": "1.1.1",
-        "unist-builder": "1.0.2",
-        "unist-util-generated": "1.1.1",
-        "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.3.0",
-        "xtend": "4.0.1"
+        "trim-lines": "^1.0.0",
+        "unist-builder": "^1.0.1",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.0",
+        "xtend": "^4.0.1"
       }
     },
     "mdurl": {
@@ -11010,7 +11012,7 @@
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "memdown": {
@@ -11018,12 +11020,12 @@
       "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
       "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
       "requires": {
-        "abstract-leveldown": "2.7.2",
-        "functional-red-black-tree": "1.0.1",
-        "immediate": "3.2.3",
-        "inherits": "2.0.3",
-        "ltgt": "2.2.1",
-        "safe-buffer": "5.1.1"
+        "abstract-leveldown": "~2.7.1",
+        "functional-red-black-tree": "^1.0.1",
+        "immediate": "^3.2.3",
+        "inherits": "~2.0.1",
+        "ltgt": "~2.2.0",
+        "safe-buffer": "~5.1.1"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -11031,7 +11033,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
           "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
           "requires": {
-            "xtend": "4.0.1"
+            "xtend": "~4.0.0"
           }
         }
       }
@@ -11041,8 +11043,8 @@
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "requires": {
-        "errno": "0.1.4",
-        "readable-stream": "2.3.3"
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
       }
     },
     "meow": {
@@ -11050,16 +11052,16 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -11067,8 +11069,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -11076,11 +11078,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "path-exists": {
@@ -11088,7 +11090,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -11096,9 +11098,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -11111,9 +11113,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -11121,8 +11123,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "strip-bom": {
@@ -11130,7 +11132,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -11160,14 +11162,14 @@
       "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.1.tgz",
       "integrity": "sha512-Qp9Mpb3xazznXzzGQBqHbqCpT2AR9joUOHYYPiQjYCarrdCPCnLWXo4BFv77y4xN26KR224xoU1n/qYY7RYYgw==",
       "requires": {
-        "async": "1.5.2",
-        "ethereumjs-util": "5.2.0",
+        "async": "^1.4.2",
+        "ethereumjs-util": "^5.0.0",
         "level-ws": "0.0.0",
-        "levelup": "1.3.9",
-        "memdown": "1.4.1",
-        "readable-stream": "2.3.3",
-        "rlp": "2.0.0",
-        "semaphore": "1.1.0"
+        "levelup": "^1.2.1",
+        "memdown": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "rlp": "^2.0.0",
+        "semaphore": ">=1.0.1"
       },
       "dependencies": {
         "async": {
@@ -11180,13 +11182,13 @@
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
           "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
           "requires": {
-            "bn.js": "4.11.8",
-            "create-hash": "1.1.3",
-            "ethjs-util": "0.1.4",
-            "keccak": "1.4.0",
-            "rlp": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "secp256k1": "3.5.0"
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
           }
         }
       }
@@ -11201,19 +11203,19 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "miller-rabin": {
@@ -11221,8 +11223,8 @@
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
       }
     },
     "mime": {
@@ -11240,7 +11242,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "~1.30.0"
       }
     },
     "mimic-fn": {
@@ -11258,8 +11260,8 @@
       "resolved": "https://registry.npmjs.org/mimos/-/mimos-3.0.3.tgz",
       "integrity": "sha1-uRCQcq03jCty9qAQHEPd+ys2ZB8=",
       "requires": {
-        "hoek": "4.2.0",
-        "mime-db": "1.30.0"
+        "hoek": "4.x.x",
+        "mime-db": "1.x.x"
       }
     },
     "minimalistic-assert": {
@@ -11277,7 +11279,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -11290,16 +11292,16 @@
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
       "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
       "requires": {
-        "concat-stream": "1.6.0",
-        "duplexify": "3.5.1",
-        "end-of-stream": "1.4.0",
-        "flush-write-stream": "1.0.2",
-        "from2": "2.3.0",
-        "parallel-transform": "1.1.0",
-        "pump": "1.0.2",
-        "pumpify": "1.3.5",
-        "stream-each": "1.2.2",
-        "through2": "2.0.3"
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^1.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
       }
     },
     "mkdirp": {
@@ -11322,12 +11324,12 @@
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
       "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
       "requires": {
-        "aproba": "1.2.0",
-        "copy-concurrently": "1.0.5",
-        "fs-write-stream-atomic": "1.0.10",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "run-queue": "1.0.3"
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
       },
       "dependencies": {
         "rimraf": {
@@ -11335,7 +11337,7 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         }
       }
@@ -11355,12 +11357,12 @@
       "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-3.1.0.tgz",
       "integrity": "sha512-QhmsD/TufS5KB7brd1rkzLz2sJqybQlDT9prroiWacaw61DtHoe2X/vcAnOu8mZc7s7ZzevFPvY5tzv3yjBXlQ==",
       "requires": {
-        "bs58": "4.0.1",
-        "ip": "1.1.5",
-        "lodash.filter": "4.6.0",
-        "lodash.map": "4.6.0",
-        "varint": "5.0.0",
-        "xtend": "4.0.1"
+        "bs58": "^4.0.1",
+        "ip": "^1.1.5",
+        "lodash.filter": "^4.6.0",
+        "lodash.map": "^4.6.0",
+        "varint": "^5.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "multibase": {
@@ -11376,8 +11378,8 @@
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.1.1.tgz",
       "integrity": "sha1-bn3oalcIcqsXBYrepxYLvsqBTd4=",
       "requires": {
-        "dns-packet": "1.2.2",
-        "thunky": "0.1.0"
+        "dns-packet": "^1.0.1",
+        "thunky": "^0.1.0"
       }
     },
     "multicast-dns-service-types": {
@@ -11390,7 +11392,7 @@
       "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.2.6.tgz",
       "integrity": "sha512-VGyRUDkxdJzWnj9x3C49MzI3+TtKKDYNfIBOaWBCNuPk6CE5CwwkL15gJtsLDfLay0fL4xTh4Af3kBbJSxSppw==",
       "requires": {
-        "varint": "5.0.0"
+        "varint": "^5.0.0"
       }
     },
     "multihashes": {
@@ -11398,8 +11400,8 @@
       "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.13.tgz",
       "integrity": "sha512-HwJGEKPCpLlNlgGQA56CYh/Wsqa+c4JAq8+mheIgw7OK5T4QvNJqgp6TH8gZ4q4l1aiWeNat/H/MrFXmTuoFfQ==",
       "requires": {
-        "bs58": "4.0.1",
-        "varint": "5.0.0"
+        "bs58": "^4.0.1",
+        "varint": "^5.0.0"
       }
     },
     "multihashing-async": {
@@ -11407,12 +11409,12 @@
       "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
       "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
       "requires": {
-        "async": "2.6.0",
-        "blakejs": "1.1.0",
-        "js-sha3": "0.7.0",
-        "multihashes": "0.4.13",
-        "murmurhash3js": "3.0.1",
-        "nodeify": "1.0.1"
+        "async": "^2.6.0",
+        "blakejs": "^1.1.0",
+        "js-sha3": "^0.7.0",
+        "multihashes": "~0.4.13",
+        "murmurhash3js": "^3.0.1",
+        "nodeify": "^1.0.1"
       },
       "dependencies": {
         "async": {
@@ -11420,18 +11422,19 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         }
       }
     },
     "multiplex": {
       "version": "github:dignifiedquire/multiplex#b5d5edd30454e2c978ee8c52df86f5f4840d2eab",
+      "from": "multiplex@github:dignifiedquire/multiplex#b5d5edd30454e2c978ee8c52df86f5f4840d2eab",
       "requires": {
-        "debug": "2.6.9",
-        "duplexify": "3.5.1",
-        "readable-stream": "2.3.3",
-        "varint": "4.0.1"
+        "debug": "^2.6.1",
+        "duplexify": "^3.4.2",
+        "readable-stream": "^2.0.2",
+        "varint": "^4.0.0"
       },
       "dependencies": {
         "debug": {
@@ -11454,17 +11457,17 @@
       "resolved": "https://registry.npmjs.org/multistream-select/-/multistream-select-0.14.2.tgz",
       "integrity": "sha512-s+e2a6YAvImGejfAy/HAovuvSArSqLG+seSs8yMCOj76dPBh+h8vyQaWkhpfpeVRTzDnNTdvNkMrFjqp97kcXg==",
       "requires": {
-        "async": "2.6.0",
-        "debug": "3.1.0",
-        "interface-connection": "0.3.2",
-        "lodash.isfunction": "3.0.9",
-        "lodash.range": "3.2.0",
-        "once": "1.4.0",
-        "pull-handshake": "1.1.4",
-        "pull-length-prefixed": "1.3.0",
-        "pull-stream": "3.6.7",
-        "semver": "5.5.0",
-        "varint": "5.0.0"
+        "async": "^2.6.0",
+        "debug": "^3.1.0",
+        "interface-connection": "~0.3.2",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.range": "^3.2.0",
+        "once": "^1.4.0",
+        "pull-handshake": "^1.1.4",
+        "pull-length-prefixed": "^1.3.0",
+        "pull-stream": "^3.6.7",
+        "semver": "^5.5.0",
+        "varint": "^5.0.0"
       },
       "dependencies": {
         "async": {
@@ -11472,7 +11475,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "semver": {
@@ -11507,7 +11510,7 @@
       "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
       "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
       "requires": {
-        "xml-char-classes": "1.0.0"
+        "xml-char-classes": "^1.0.0"
       }
     },
     "ndjson": {
@@ -11515,10 +11518,10 @@
       "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.5.0.tgz",
       "integrity": "sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=",
       "requires": {
-        "json-stringify-safe": "5.0.1",
-        "minimist": "1.2.0",
-        "split2": "2.2.0",
-        "through2": "2.0.3"
+        "json-stringify-safe": "^5.0.1",
+        "minimist": "^1.2.0",
+        "split2": "^2.1.0",
+        "through2": "^2.0.3"
       }
     },
     "nearley": {
@@ -11527,9 +11530,9 @@
       "integrity": "sha512-clqqhEuP0ZCJQ85Xv2I/4o2Gs/fvSR6fCg5ZHVE2c8evWyNk2G++ih4JOO3lMb/k/09x6ihQ2nzKUlB/APCWjg==",
       "dev": true,
       "requires": {
-        "nomnom": "1.6.2",
-        "railroad-diagrams": "1.0.0",
-        "randexp": "0.4.6"
+        "nomnom": "~1.6.2",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "^0.4.2"
       }
     },
     "negotiator": {
@@ -11542,8 +11545,8 @@
       "resolved": "https://registry.npmjs.org/nigel/-/nigel-2.0.2.tgz",
       "integrity": "sha1-k6GGb7DFLYc5CqdeKxYfS1x15bE=",
       "requires": {
-        "hoek": "4.2.0",
-        "vise": "2.0.2"
+        "hoek": "4.x.x",
+        "vise": "2.x.x"
       }
     },
     "no-case": {
@@ -11551,7 +11554,7 @@
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
       "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.1"
       }
     },
     "node-abi": {
@@ -11559,7 +11562,7 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.0.tgz",
       "integrity": "sha512-hRUz0vG+eJfSqwU6rOgW6wNyX85ec8OEE9n4A+u+eoiE8oTePhCkUFTNmwQ+86Kyu429PCLNNyI2P2jL9qKXhw==",
       "requires": {
-        "semver": "5.4.1"
+        "semver": "^5.4.1"
       }
     },
     "node-fetch": {
@@ -11567,8 +11570,8 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
       }
     },
     "node-forge": {
@@ -11586,28 +11589,28 @@
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
       "integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
       "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.1.4",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.11.1",
-        "domain-browser": "1.1.7",
-        "events": "1.1.1",
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.1.4",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^1.0.0",
         "https-browserify": "0.0.1",
-        "os-browserify": "0.2.1",
+        "os-browserify": "^0.2.0",
         "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.3",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.7.2",
-        "string_decoder": "0.10.31",
-        "timers-browserify": "2.0.4",
+        "process": "^0.11.0",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.0.5",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.3.1",
+        "string_decoder": "^0.10.25",
+        "timers-browserify": "^2.0.2",
         "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.3",
+        "url": "^0.11.0",
+        "util": "^0.10.3",
         "vm-browserify": "0.0.4"
       },
       "dependencies": {
@@ -11628,10 +11631,10 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
       "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
       "requires": {
-        "growly": "1.3.0",
-        "semver": "5.4.1",
-        "shellwords": "0.1.1",
-        "which": "1.3.0"
+        "growly": "^1.3.0",
+        "semver": "^5.3.0",
+        "shellwords": "^0.1.0",
+        "which": "^1.2.12"
       }
     },
     "node-status-codes": {
@@ -11644,8 +11647,8 @@
       "resolved": "https://registry.npmjs.org/nodeify/-/nodeify-1.0.1.tgz",
       "integrity": "sha1-ZKtpp7268DzhB7TwM1yHwLnpGx0=",
       "requires": {
-        "is-promise": "1.0.1",
-        "promise": "1.3.0"
+        "is-promise": "~1.0.0",
+        "promise": "~1.3.0"
       },
       "dependencies": {
         "is-promise": {
@@ -11658,7 +11661,7 @@
           "resolved": "https://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
           "integrity": "sha1-5cyaTIJ45GZP/twBx9qEhCsEAXU=",
           "requires": {
-            "is-promise": "1.0.1"
+            "is-promise": "~1"
           }
         }
       }
@@ -11669,8 +11672,8 @@
       "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
       "dev": true,
       "requires": {
-        "colors": "0.5.1",
-        "underscore": "1.4.4"
+        "colors": "0.5.x",
+        "underscore": "~1.4.4"
       }
     },
     "noop-logger": {
@@ -11683,10 +11686,10 @@
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -11694,7 +11697,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "normalize-range": {
@@ -11707,10 +11710,10 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
       "requires": {
-        "object-assign": "4.1.1",
-        "prepend-http": "1.0.4",
-        "query-string": "4.3.4",
-        "sort-keys": "1.1.2"
+        "object-assign": "^4.0.1",
+        "prepend-http": "^1.0.0",
+        "query-string": "^4.1.0",
+        "sort-keys": "^1.0.0"
       }
     },
     "npm-run-path": {
@@ -11718,7 +11721,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "npmlog": {
@@ -11726,10 +11729,10 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "nth-check": {
@@ -11737,7 +11740,7 @@
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "requires": {
-        "boolbase": "1.0.0"
+        "boolbase": "~1.0.0"
       }
     },
     "num2fraction": {
@@ -11792,9 +11795,9 @@
       "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.1",
-        "object-keys": "1.0.11"
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.0",
+        "object-keys": "^1.0.10"
       }
     },
     "object.entries": {
@@ -11803,10 +11806,10 @@
       "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.8.2",
-        "function-bind": "1.1.1",
-        "has": "1.0.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.6.1",
+        "function-bind": "^1.1.0",
+        "has": "^1.0.1"
       }
     },
     "object.omit": {
@@ -11814,8 +11817,8 @@
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "object.values": {
@@ -11824,10 +11827,10 @@
       "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
       "dev": true,
       "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.8.2",
-        "function-bind": "1.1.1",
-        "has": "1.0.1"
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.6.1",
+        "function-bind": "^1.1.0",
+        "has": "^1.0.1"
       }
     },
     "obuf": {
@@ -11853,7 +11856,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -11861,7 +11864,7 @@
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "opn": {
@@ -11869,7 +11872,7 @@
       "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
       "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
       "requires": {
-        "is-wsl": "1.1.0"
+        "is-wsl": "^1.1.0"
       }
     },
     "optimist": {
@@ -11877,8 +11880,8 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -11904,12 +11907,12 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "options": {
@@ -11922,7 +11925,7 @@
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
       "integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
       "requires": {
-        "url-parse": "1.0.5"
+        "url-parse": "1.0.x"
       },
       "dependencies": {
         "url-parse": {
@@ -11930,8 +11933,8 @@
           "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
           "integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
           "requires": {
-            "querystringify": "0.0.4",
-            "requires-port": "1.0.0"
+            "querystringify": "0.0.x",
+            "requires-port": "1.0.x"
           }
         }
       }
@@ -11951,9 +11954,9 @@
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       }
     },
     "os-tmpdir": {
@@ -11966,8 +11969,8 @@
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "p-finally": {
@@ -11985,7 +11988,7 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-map": {
@@ -11998,10 +12001,10 @@
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "requires": {
-        "got": "6.7.1",
-        "registry-auth-token": "3.3.1",
-        "registry-url": "3.1.0",
-        "semver": "5.4.1"
+        "got": "^6.7.1",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
       }
     },
     "parallel-transform": {
@@ -12009,9 +12012,9 @@
       "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
       "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
       "requires": {
-        "cyclist": "0.2.2",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "cyclist": "~0.2.2",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
       }
     },
     "param-case": {
@@ -12019,7 +12022,7 @@
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
       "requires": {
-        "no-case": "2.3.2"
+        "no-case": "^2.2.0"
       }
     },
     "parchment": {
@@ -12032,11 +12035,11 @@
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "requires": {
-        "asn1.js": "4.9.1",
-        "browserify-aes": "1.0.8",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.14"
+        "asn1.js": "^4.0.0",
+        "browserify-aes": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3"
       }
     },
     "parse-entities": {
@@ -12044,12 +12047,12 @@
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.2.tgz",
       "integrity": "sha512-5N9lmQ7tmxfXf+hO3X6KRG6w7uYO/HL9fHalSySTdyn63C3WNvTM/1R8tn1u1larNcEbo3Slcy2bsVDQqvEpUg==",
       "requires": {
-        "character-entities": "1.2.2",
-        "character-entities-legacy": "1.1.2",
-        "character-reference-invalid": "1.1.2",
-        "is-alphanumerical": "1.0.2",
-        "is-decimal": "1.0.2",
-        "is-hexadecimal": "1.0.2"
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
       }
     },
     "parse-glob": {
@@ -12057,10 +12060,10 @@
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parse-json": {
@@ -12068,7 +12071,7 @@
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parse-passwd": {
@@ -12082,7 +12085,7 @@
       "integrity": "sha1-Be/1fw70V3+xRKefi5qWemzERRA=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.88"
+        "@types/node": "^6.0.46"
       }
     },
     "parseqs": {
@@ -12090,7 +12093,7 @@
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseuri": {
@@ -12098,7 +12101,7 @@
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
       "requires": {
-        "better-assert": "1.0.2"
+        "better-assert": "~1.0.0"
       }
     },
     "parseurl": {
@@ -12156,7 +12159,7 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -12171,11 +12174,11 @@
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
       "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
       "requires": {
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.8"
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "peer-book": {
@@ -12183,9 +12186,9 @@
       "resolved": "https://registry.npmjs.org/peer-book/-/peer-book-0.5.4.tgz",
       "integrity": "sha512-BuI/mO6OarE5839h9KLG+gSF8UPHlN8VIo6A9ZF4RlcYfOjAuOtDwgAmKIEpf3lTmVqqIkwD92KIij237yphaw==",
       "requires": {
-        "bs58": "4.0.1",
-        "peer-id": "0.10.7",
-        "peer-info": "0.11.6"
+        "bs58": "^4.0.1",
+        "peer-id": "^0.10.5",
+        "peer-info": "^0.11.6"
       }
     },
     "peer-id": {
@@ -12193,10 +12196,10 @@
       "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
       "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
       "requires": {
-        "async": "2.6.0",
-        "libp2p-crypto": "0.12.1",
-        "lodash": "4.17.10",
-        "multihashes": "0.4.13"
+        "async": "^2.6.0",
+        "libp2p-crypto": "~0.12.1",
+        "lodash": "^4.17.5",
+        "multihashes": "~0.4.13"
       },
       "dependencies": {
         "asn1.js": {
@@ -12204,9 +12207,9 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.0.0.tgz",
           "integrity": "sha512-Y+FKviD0uyIWWo/xE0XkUl0x1allKFhzEVJ+//2Dgqpy+n+B77MlPNqvyk7Vx50M9XyVzjnRhDqJAEAsyivlbA==",
           "requires": {
-            "bn.js": "4.11.8",
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.0"
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "async": {
@@ -12214,7 +12217,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "requires": {
-            "lodash": "4.17.10"
+            "lodash": "^4.14.0"
           }
         },
         "browserify-aes": {
@@ -12222,12 +12225,12 @@
           "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
           "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
           "requires": {
-            "buffer-xor": "1.0.3",
-            "cipher-base": "1.0.4",
-            "create-hash": "1.1.3",
-            "evp_bytestokey": "1.0.3",
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
+            "buffer-xor": "^1.0.3",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.3",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "libp2p-crypto": {
@@ -12235,18 +12238,18 @@
           "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
           "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
           "requires": {
-            "asn1.js": "5.0.0",
-            "async": "2.6.0",
-            "browserify-aes": "1.2.0",
-            "bs58": "4.0.1",
-            "keypair": "1.0.1",
-            "libp2p-crypto-secp256k1": "0.2.2",
-            "multihashing-async": "0.4.8",
-            "node-forge": "0.7.5",
-            "pem-jwk": "1.5.1",
-            "protons": "1.0.1",
-            "rsa-pem-to-jwk": "1.1.3",
-            "tweetnacl": "1.0.0",
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.1.1",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.7",
+            "node-forge": "^0.7.1",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
             "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           }
         },
@@ -12272,9 +12275,9 @@
       "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.11.6.tgz",
       "integrity": "sha512-xrVNiAF1IhVJNGEg5P2UQN+subaEkszT8YkC3zdy06MK0vTH3cMHB+HH+ZURkoSLssc3HbK58ecXeKpQ/4zq5w==",
       "requires": {
-        "lodash.uniqby": "4.7.0",
-        "multiaddr": "3.1.0",
-        "peer-id": "0.10.7"
+        "lodash.uniqby": "^4.7.0",
+        "multiaddr": "^3.0.2",
+        "peer-id": "~0.10.5"
       }
     },
     "peerpad-core": {
@@ -12282,33 +12285,33 @@
       "resolved": "https://registry.npmjs.org/peerpad-core/-/peerpad-core-0.11.0.tgz",
       "integrity": "sha512-3RqZ6pJqgFjvOXmTg7d1NYGYkfuH4bwQsofvlrnXPn4J/aA1kSUs0xtJ8XpZQsG8lkPsppeVebz9ebQnQIv5sg==",
       "requires": {
-        "aes-js": "3.1.1",
-        "async": "2.5.0",
-        "bootstrap": "3.3.7",
-        "bs58": "4.0.1",
-        "history": "4.7.2",
-        "ipfs": "0.28.2",
-        "libp2p-crypto": "0.10.4",
-        "pify": "3.0.0",
-        "prop-types": "15.6.0",
-        "quill": "1.3.6",
-        "quill-delta-to-html": "0.5.1",
-        "react": "15.6.2",
-        "react-dom": "15.6.2",
+        "aes-js": "^3.1.0",
+        "async": "^2.5.0",
+        "bootstrap": "^3.3.7",
+        "bs58": "^4.0.1",
+        "history": "^4.7.2",
+        "ipfs": "~0.28.2",
+        "libp2p-crypto": "^0.10.3",
+        "pify": "^3.0.0",
+        "prop-types": "^15.6.0",
+        "quill": "^1.3.3",
+        "quill-delta-to-html": "^0.5.1",
+        "react": "^15.6.2",
+        "react-dom": "^15.6.2",
         "react-scripts": "1.0.13",
-        "remark": "8.0.0",
-        "remark-html": "6.0.1",
-        "remark-html-katex": "1.1.0",
-        "remark-math": "1.0.3",
-        "safe-buffer": "5.1.1",
-        "y-array": "10.1.4",
-        "y-indexeddb-encrypted": "0.0.1",
-        "y-ipfs-connector": "2.2.0",
-        "y-map": "10.1.3",
-        "y-memory": "8.0.9",
-        "y-richtext": "9.0.8",
-        "y-text": "9.5.1",
-        "yjs": "12.3.3"
+        "remark": "^8.0.0",
+        "remark-html": "^6.0.1",
+        "remark-html-katex": "^1.0.2",
+        "remark-math": "^1.0.1",
+        "safe-buffer": "^5.1.1",
+        "y-array": "^10.1.4",
+        "y-indexeddb-encrypted": "^0.0.1",
+        "y-ipfs-connector": "^2.2.0",
+        "y-map": "^10.1.3",
+        "y-memory": "^8.0.9",
+        "y-richtext": "^9.0.8",
+        "y-text": "^9.5.1",
+        "yjs": "^12.3.3"
       },
       "dependencies": {
         "clone": {
@@ -12326,12 +12329,12 @@
           "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.6.tgz",
           "integrity": "sha512-K0mvhimWZN6s+9OQ249CH2IEPZ9JmkFuCQeHAOQax3EZ2nDJ3wfGh59mnlQaZV2i7u8eFarx6wAtvQKgShojug==",
           "requires": {
-            "clone": "2.1.1",
-            "deep-equal": "1.0.1",
-            "eventemitter3": "2.0.3",
-            "extend": "3.0.1",
-            "parchment": "1.1.4",
-            "quill-delta": "3.6.2"
+            "clone": "^2.1.1",
+            "deep-equal": "^1.0.1",
+            "eventemitter3": "^2.0.3",
+            "extend": "^3.0.1",
+            "parchment": "^1.1.4",
+            "quill-delta": "^3.6.2"
           }
         }
       }
@@ -12349,9 +12352,9 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-1.0.3.tgz",
           "integrity": "sha1-KBuj7B8kSP52X5Kk7s+IP+E2S1Q=",
           "requires": {
-            "bn.js": "1.3.0",
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.0"
+            "bn.js": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "bn.js": {
@@ -12372,11 +12375,11 @@
       "resolved": "https://registry.npmjs.org/pez/-/pez-2.1.5.tgz",
       "integrity": "sha1-XsLMYlAMw+tCNtSkFM9aF7XrUAc=",
       "requires": {
-        "b64": "3.0.3",
-        "boom": "5.2.0",
-        "content": "3.0.7",
-        "hoek": "4.2.0",
-        "nigel": "2.0.2"
+        "b64": "3.x.x",
+        "boom": "5.x.x",
+        "content": "3.x.x",
+        "hoek": "4.x.x",
+        "nigel": "2.x.x"
       }
     },
     "pify": {
@@ -12394,7 +12397,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -12402,7 +12405,7 @@
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "requires": {
-        "find-up": "2.1.0"
+        "find-up": "^2.1.0"
       }
     },
     "pluralize": {
@@ -12415,9 +12418,9 @@
       "resolved": "https://registry.npmjs.org/podium/-/podium-1.3.0.tgz",
       "integrity": "sha512-ZIujqk1pv8bRZNVxwwwq0BhXilZ2udycQT3Kp8ah3f3TcTmVg7ILJsv/oLf47gRa2qeiP584lNq+pfvS9U3aow==",
       "requires": {
-        "hoek": "4.2.0",
-        "items": "2.1.1",
-        "joi": "10.6.0"
+        "hoek": "4.x.x",
+        "items": "2.x.x",
+        "joi": "10.x.x"
       },
       "dependencies": {
         "joi": {
@@ -12425,10 +12428,10 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
           "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
           "requires": {
-            "hoek": "4.2.0",
-            "isemail": "2.2.1",
-            "items": "2.1.1",
-            "topo": "2.0.2"
+            "hoek": "4.x.x",
+            "isemail": "2.x.x",
+            "items": "2.x.x",
+            "topo": "2.x.x"
           }
         }
       }
@@ -12438,9 +12441,9 @@
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
       "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
       "requires": {
-        "async": "1.5.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1"
+        "async": "^1.5.2",
+        "debug": "^2.2.0",
+        "mkdirp": "0.5.x"
       },
       "dependencies": {
         "async": {
@@ -12463,9 +12466,9 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.12.tgz",
       "integrity": "sha512-K6SLofXEK43FBSyZ6/ExQV7ji24OEw4tEY6x1CAf7+tcoMWJoO24Rf3rVFVpk+5IQL1e1Cy3sTKfg7hXuLzafg==",
       "requires": {
-        "chalk": "2.1.0",
-        "source-map": "0.5.7",
-        "supports-color": "4.4.0"
+        "chalk": "^2.1.0",
+        "source-map": "^0.5.7",
+        "supports-color": "^4.4.0"
       },
       "dependencies": {
         "chalk": {
@@ -12473,9 +12476,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         }
       }
@@ -12485,9 +12488,9 @@
       "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
       "requires": {
-        "postcss": "5.2.17",
-        "postcss-message-helpers": "2.0.0",
-        "reduce-css-calc": "1.3.0"
+        "postcss": "^5.0.2",
+        "postcss-message-helpers": "^2.0.0",
+        "reduce-css-calc": "^1.2.6"
       },
       "dependencies": {
         "has-flag": {
@@ -12500,10 +12503,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -12511,7 +12514,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -12521,9 +12524,9 @@
       "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
       "requires": {
-        "colormin": "1.1.2",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
+        "colormin": "^1.0.5",
+        "postcss": "^5.0.13",
+        "postcss-value-parser": "^3.2.3"
       },
       "dependencies": {
         "has-flag": {
@@ -12536,10 +12539,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -12547,7 +12550,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -12557,8 +12560,8 @@
       "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
       "requires": {
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
+        "postcss": "^5.0.11",
+        "postcss-value-parser": "^3.1.2"
       },
       "dependencies": {
         "has-flag": {
@@ -12571,10 +12574,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -12582,7 +12585,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -12592,9 +12595,9 @@
       "resolved": "https://registry.npmjs.org/postcss-css-variables/-/postcss-css-variables-0.8.0.tgz",
       "integrity": "sha512-ilcsJMhq09HOsQ2RzXm+fPQNEwMN3kLab6IYpcL5EH8E1EKvBrWQRsiWONWqjWPAKHFMWkEvJTHJJzP9m1E0yQ==",
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "extend": "3.0.1",
-        "postcss": "6.0.12"
+        "escape-string-regexp": "^1.0.3",
+        "extend": "^3.0.1",
+        "postcss": "^6.0.8"
       }
     },
     "postcss-discard-comments": {
@@ -12602,7 +12605,7 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
       "requires": {
-        "postcss": "5.2.17"
+        "postcss": "^5.0.14"
       },
       "dependencies": {
         "has-flag": {
@@ -12615,10 +12618,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -12626,7 +12629,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -12636,7 +12639,7 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
       "requires": {
-        "postcss": "5.2.17"
+        "postcss": "^5.0.4"
       },
       "dependencies": {
         "has-flag": {
@@ -12649,10 +12652,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -12660,7 +12663,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -12670,7 +12673,7 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
       "requires": {
-        "postcss": "5.2.17"
+        "postcss": "^5.0.14"
       },
       "dependencies": {
         "has-flag": {
@@ -12683,10 +12686,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -12694,7 +12697,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -12704,7 +12707,7 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
       "requires": {
-        "postcss": "5.2.17"
+        "postcss": "^5.0.16"
       },
       "dependencies": {
         "has-flag": {
@@ -12717,10 +12720,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -12728,7 +12731,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -12738,8 +12741,8 @@
       "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
       "requires": {
-        "postcss": "5.2.17",
-        "uniqs": "2.0.0"
+        "postcss": "^5.0.14",
+        "uniqs": "^2.0.0"
       },
       "dependencies": {
         "has-flag": {
@@ -12752,10 +12755,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -12763,7 +12766,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -12773,8 +12776,8 @@
       "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
       "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
       "requires": {
-        "postcss": "5.2.17",
-        "uniqid": "4.1.1"
+        "postcss": "^5.0.4",
+        "uniqid": "^4.0.0"
       },
       "dependencies": {
         "has-flag": {
@@ -12787,10 +12790,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -12798,7 +12801,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -12808,7 +12811,7 @@
       "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-3.2.0.tgz",
       "integrity": "sha512-0AuD9HG1Ey3/3nqPWu9yqf7rL0KCPu5VgjDsjf5mzEcuo9H/z8nco/fljKgjsOUrZypa95MI0kS4xBZeBzz2lw==",
       "requires": {
-        "postcss": "6.0.12"
+        "postcss": "^6.0.1"
       }
     },
     "postcss-import": {
@@ -12816,10 +12819,10 @@
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-11.0.0.tgz",
       "integrity": "sha1-qWLi34LTvFptpqOGhBdHIE9B71s=",
       "requires": {
-        "postcss": "6.0.12",
-        "postcss-value-parser": "3.3.0",
-        "read-cache": "1.0.0",
-        "resolve": "1.4.0"
+        "postcss": "^6.0.1",
+        "postcss-value-parser": "^3.2.3",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
       }
     },
     "postcss-load-config": {
@@ -12827,10 +12830,10 @@
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
       "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
       "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1",
-        "postcss-load-options": "1.2.0",
-        "postcss-load-plugins": "2.3.0"
+        "cosmiconfig": "^2.1.0",
+        "object-assign": "^4.1.0",
+        "postcss-load-options": "^1.2.0",
+        "postcss-load-plugins": "^2.3.0"
       }
     },
     "postcss-load-options": {
@@ -12838,8 +12841,8 @@
       "resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
       "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
       "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1"
+        "cosmiconfig": "^2.1.0",
+        "object-assign": "^4.1.0"
       }
     },
     "postcss-load-plugins": {
@@ -12847,8 +12850,8 @@
       "resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
       "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
       "requires": {
-        "cosmiconfig": "2.2.2",
-        "object-assign": "4.1.1"
+        "cosmiconfig": "^2.1.1",
+        "object-assign": "^4.1.0"
       }
     },
     "postcss-loader": {
@@ -12856,10 +12859,10 @@
       "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.0.6.tgz",
       "integrity": "sha512-HIq7yy1hh9KI472Y38iSRV4WupZUNy6zObkxQM/ZuInoaE2+PyX4NcO6jjP5HG5mXL7j5kcNEl0fAG4Kva7O9w==",
       "requires": {
-        "loader-utils": "1.1.0",
-        "postcss": "6.0.12",
-        "postcss-load-config": "1.2.0",
-        "schema-utils": "0.3.0"
+        "loader-utils": "^1.1.0",
+        "postcss": "^6.0.2",
+        "postcss-load-config": "^1.2.0",
+        "schema-utils": "^0.3.0"
       }
     },
     "postcss-merge-idents": {
@@ -12867,9 +12870,9 @@
       "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
       "requires": {
-        "has": "1.0.1",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
+        "has": "^1.0.1",
+        "postcss": "^5.0.10",
+        "postcss-value-parser": "^3.1.1"
       },
       "dependencies": {
         "has-flag": {
@@ -12882,10 +12885,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -12893,7 +12896,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -12903,7 +12906,7 @@
       "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
       "requires": {
-        "postcss": "5.2.17"
+        "postcss": "^5.0.4"
       },
       "dependencies": {
         "has-flag": {
@@ -12916,10 +12919,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -12927,7 +12930,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -12937,11 +12940,11 @@
       "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
       "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-api": "1.6.1",
-        "postcss": "5.2.17",
-        "postcss-selector-parser": "2.2.3",
-        "vendors": "1.0.1"
+        "browserslist": "^1.5.2",
+        "caniuse-api": "^1.5.2",
+        "postcss": "^5.0.4",
+        "postcss-selector-parser": "^2.2.2",
+        "vendors": "^1.0.0"
       },
       "dependencies": {
         "browserslist": {
@@ -12949,8 +12952,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "requires": {
-            "caniuse-db": "1.0.30000741",
-            "electron-to-chromium": "1.3.24"
+            "caniuse-db": "^1.0.30000639",
+            "electron-to-chromium": "^1.2.7"
           }
         },
         "has-flag": {
@@ -12963,10 +12966,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -12974,7 +12977,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -12989,9 +12992,9 @@
       "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
       "requires": {
-        "object-assign": "4.1.1",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
+        "object-assign": "^4.0.1",
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.2"
       },
       "dependencies": {
         "has-flag": {
@@ -13004,10 +13007,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -13015,7 +13018,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13025,8 +13028,8 @@
       "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
       "requires": {
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
+        "postcss": "^5.0.12",
+        "postcss-value-parser": "^3.3.0"
       },
       "dependencies": {
         "has-flag": {
@@ -13039,10 +13042,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -13050,7 +13053,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13060,10 +13063,10 @@
       "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0",
-        "uniqs": "2.0.0"
+        "alphanum-sort": "^1.0.1",
+        "postcss": "^5.0.2",
+        "postcss-value-parser": "^3.0.2",
+        "uniqs": "^2.0.0"
       },
       "dependencies": {
         "has-flag": {
@@ -13076,10 +13079,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -13087,7 +13090,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13097,10 +13100,10 @@
       "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "has": "1.0.1",
-        "postcss": "5.2.17",
-        "postcss-selector-parser": "2.2.3"
+        "alphanum-sort": "^1.0.2",
+        "has": "^1.0.1",
+        "postcss": "^5.0.14",
+        "postcss-selector-parser": "^2.0.0"
       },
       "dependencies": {
         "has-flag": {
@@ -13113,10 +13116,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -13124,7 +13127,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13134,7 +13137,7 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "requires": {
-        "postcss": "6.0.12"
+        "postcss": "^6.0.1"
       }
     },
     "postcss-modules-local-by-default": {
@@ -13142,8 +13145,8 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "requires": {
-        "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.12"
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
       }
     },
     "postcss-modules-scope": {
@@ -13151,8 +13154,8 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "requires": {
-        "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.12"
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
       }
     },
     "postcss-modules-values": {
@@ -13160,8 +13163,8 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "requires": {
-        "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.12"
+        "icss-replace-symbols": "^1.1.0",
+        "postcss": "^6.0.1"
       }
     },
     "postcss-normalize-charset": {
@@ -13169,7 +13172,7 @@
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
       "requires": {
-        "postcss": "5.2.17"
+        "postcss": "^5.0.5"
       },
       "dependencies": {
         "has-flag": {
@@ -13182,10 +13185,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -13193,7 +13196,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13203,10 +13206,10 @@
       "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
       "requires": {
-        "is-absolute-url": "2.1.0",
-        "normalize-url": "1.9.1",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
+        "is-absolute-url": "^2.0.0",
+        "normalize-url": "^1.4.0",
+        "postcss": "^5.0.14",
+        "postcss-value-parser": "^3.2.3"
       },
       "dependencies": {
         "has-flag": {
@@ -13219,10 +13222,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -13230,7 +13233,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13240,8 +13243,8 @@
       "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
       "requires": {
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.1"
       },
       "dependencies": {
         "has-flag": {
@@ -13254,10 +13257,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -13265,7 +13268,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13275,8 +13278,8 @@
       "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
       "requires": {
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
+        "postcss": "^5.0.4",
+        "postcss-value-parser": "^3.0.2"
       },
       "dependencies": {
         "has-flag": {
@@ -13289,10 +13292,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -13300,7 +13303,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13310,7 +13313,7 @@
       "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
       "requires": {
-        "postcss": "5.2.17"
+        "postcss": "^5.0.4"
       },
       "dependencies": {
         "has-flag": {
@@ -13323,10 +13326,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -13334,7 +13337,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13344,9 +13347,9 @@
       "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
       "requires": {
-        "has": "1.0.1",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
+        "has": "^1.0.1",
+        "postcss": "^5.0.8",
+        "postcss-value-parser": "^3.0.1"
       },
       "dependencies": {
         "has-flag": {
@@ -13359,10 +13362,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -13370,7 +13373,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13380,9 +13383,9 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
       "requires": {
-        "flatten": "1.0.2",
-        "indexes-of": "1.0.1",
-        "uniq": "1.0.1"
+        "flatten": "^1.0.2",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
       }
     },
     "postcss-svgo": {
@@ -13390,10 +13393,10 @@
       "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
       "requires": {
-        "is-svg": "2.1.0",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0",
-        "svgo": "0.7.2"
+        "is-svg": "^2.0.0",
+        "postcss": "^5.0.14",
+        "postcss-value-parser": "^3.2.3",
+        "svgo": "^0.7.0"
       },
       "dependencies": {
         "has-flag": {
@@ -13406,10 +13409,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -13417,7 +13420,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13427,9 +13430,9 @@
       "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
       "requires": {
-        "alphanum-sort": "1.0.2",
-        "postcss": "5.2.17",
-        "uniqs": "2.0.0"
+        "alphanum-sort": "^1.0.1",
+        "postcss": "^5.0.4",
+        "uniqs": "^2.0.0"
       },
       "dependencies": {
         "has-flag": {
@@ -13442,10 +13445,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -13453,7 +13456,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13468,9 +13471,9 @@
       "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
       "requires": {
-        "has": "1.0.1",
-        "postcss": "5.2.17",
-        "uniqs": "2.0.0"
+        "has": "^1.0.1",
+        "postcss": "^5.0.4",
+        "uniqs": "^2.0.0"
       },
       "dependencies": {
         "has-flag": {
@@ -13483,10 +13486,10 @@
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
           "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
           "requires": {
-            "chalk": "1.1.3",
-            "js-base64": "2.3.2",
-            "source-map": "0.5.7",
-            "supports-color": "3.2.3"
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
           }
         },
         "supports-color": {
@@ -13494,7 +13497,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -13505,9 +13508,9 @@
       "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "spawn-sync": "1.0.15",
-        "which": "1.2.14"
+        "cross-spawn": "^5.0.1",
+        "spawn-sync": "^1.0.15",
+        "which": "1.2.x"
       },
       "dependencies": {
         "concat-stream": {
@@ -13516,9 +13519,9 @@
           "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "typedarray": "0.0.6"
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         },
         "core-util-is": {
@@ -13533,9 +13536,9 @@
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "dev": true,
           "requires": {
-            "lru-cache": "4.1.1",
-            "shebang-command": "1.2.0",
-            "which": "1.2.14"
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "inherits": {
@@ -13562,8 +13565,8 @@
           "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "os-shim": {
@@ -13590,13 +13593,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "safe-buffer": {
@@ -13611,7 +13614,7 @@
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
-            "shebang-regex": "1.0.0"
+            "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
@@ -13626,8 +13629,8 @@
           "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
           "dev": true,
           "requires": {
-            "concat-stream": "1.6.0",
-            "os-shim": "0.1.3"
+            "concat-stream": "^1.4.7",
+            "os-shim": "^0.1.2"
           }
         },
         "string_decoder": {
@@ -13636,7 +13639,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "typedarray": {
@@ -13657,7 +13660,7 @@
           "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         },
         "yallist": {
@@ -13673,21 +13676,21 @@
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
       "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
       "requires": {
-        "detect-libc": "1.0.3",
-        "expand-template": "1.1.0",
+        "detect-libc": "^1.0.3",
+        "expand-template": "^1.0.2",
         "github-from-package": "0.0.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "node-abi": "2.4.0",
-        "noop-logger": "0.1.1",
-        "npmlog": "4.1.2",
-        "os-homedir": "1.0.2",
-        "pump": "2.0.1",
-        "rc": "1.2.1",
-        "simple-get": "2.8.1",
-        "tar-fs": "1.16.2",
-        "tunnel-agent": "0.6.0",
-        "which-pm-runs": "1.0.0"
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "node-abi": "^2.2.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "os-homedir": "^1.0.1",
+        "pump": "^2.0.1",
+        "rc": "^1.1.6",
+        "simple-get": "^2.7.0",
+        "tar-fs": "^1.13.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
       },
       "dependencies": {
         "pump": {
@@ -13695,8 +13698,8 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "requires": {
-            "end-of-stream": "1.4.0",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         }
       }
@@ -13726,8 +13729,8 @@
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
       "requires": {
-        "renderkid": "2.0.1",
-        "utila": "0.4.0"
+        "renderkid": "^2.0.1",
+        "utila": "~0.4"
       }
     },
     "pretty-format": {
@@ -13735,8 +13738,8 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-20.0.3.tgz",
       "integrity": "sha1-Ag41ClYKH+GpjcO+tsz/s4beixQ=",
       "requires": {
-        "ansi-regex": "2.1.1",
-        "ansi-styles": "3.2.0"
+        "ansi-regex": "^2.1.1",
+        "ansi-styles": "^3.0.0"
       }
     },
     "priorityqueue": {
@@ -13769,7 +13772,7 @@
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-10.2.3.tgz",
       "integrity": "sha512-Xboq5+TdUwuQtSSDRZRNnb5NprINlgQN999VqUjZxnLKydUNLeIPx6Eiahg6oJua3XBg2TGnh5Cth1s4I6+r7g==",
       "requires": {
-        "tdigest": "0.1.1"
+        "tdigest": "^0.1.1"
       }
     },
     "prometheus-gc-stats": {
@@ -13778,8 +13781,8 @@
       "integrity": "sha1-RxO8Xp9znuCahslkAU37zk/VAAM=",
       "optional": true,
       "requires": {
-        "gc-stats": "1.1.1",
-        "optional": "0.1.4"
+        "gc-stats": "^1.0.0",
+        "optional": "^0.1.3"
       }
     },
     "promise": {
@@ -13787,7 +13790,7 @@
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.1.tgz",
       "integrity": "sha1-5F1osAoXZHttpxG/he1u1HII9FA=",
       "requires": {
-        "asap": "2.0.6"
+        "asap": "~2.0.3"
       }
     },
     "promise-inflight": {
@@ -13805,9 +13808,9 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
       "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.16",
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
       }
     },
     "property-information": {
@@ -13825,10 +13828,10 @@
       "resolved": "https://registry.npmjs.org/protons/-/protons-1.0.1.tgz",
       "integrity": "sha512-+0ZKnfVs+4c43tbAQ5j0Mck8wPcLnlxUYzKQoB4iDW4ocdXGnN4P+0dDbgX1FTpoY9+7P2Tn2scJyHHqj+S/lQ==",
       "requires": {
-        "protocol-buffers-schema": "3.3.2",
-        "safe-buffer": "5.1.1",
-        "signed-varint": "2.0.1",
-        "varint": "5.0.0"
+        "protocol-buffers-schema": "^3.3.1",
+        "safe-buffer": "^5.1.1",
+        "signed-varint": "^2.0.1",
+        "varint": "^5.0.0"
       }
     },
     "proxy-addr": {
@@ -13836,7 +13839,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
       "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.5.2"
       }
     },
@@ -13855,11 +13858,11 @@
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
       "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "parse-asn1": "5.1.0",
-        "randombytes": "2.0.5"
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1"
       }
     },
     "pull-abortable": {
@@ -13872,7 +13875,7 @@
       "resolved": "https://registry.npmjs.org/pull-batch/-/pull-batch-1.0.0.tgz",
       "integrity": "sha1-OopwhNsOmDxcWb8OB0qkHnU/Alg=",
       "requires": {
-        "pull-through": "1.0.18"
+        "pull-through": "^1.0.18"
       }
     },
     "pull-block": {
@@ -13880,7 +13883,7 @@
       "resolved": "https://registry.npmjs.org/pull-block/-/pull-block-1.4.0.tgz",
       "integrity": "sha512-nqrFveL9SWdpM9FDkgUVifhbH/dgtK65Pmwa/rrdvB9avE32uWXb1uiemxczfrkqZaG4XVc139KdqfyvPoraoA==",
       "requires": {
-        "pull-through": "1.0.18"
+        "pull-through": "^1.0.18"
       }
     },
     "pull-cat": {
@@ -13903,7 +13906,7 @@
       "resolved": "https://registry.npmjs.org/pull-file/-/pull-file-1.1.0.tgz",
       "integrity": "sha1-HdmHYF1jV6DSPB5Lgm95FaIVEpw=",
       "requires": {
-        "pull-utf8-decoder": "1.0.2"
+        "pull-utf8-decoder": "^1.0.2"
       }
     },
     "pull-handshake": {
@@ -13911,10 +13914,10 @@
       "resolved": "https://registry.npmjs.org/pull-handshake/-/pull-handshake-1.1.4.tgz",
       "integrity": "sha1-YACg/QGIhM39c3JU+Mxgqypjd5E=",
       "requires": {
-        "pull-cat": "1.1.11",
-        "pull-pair": "1.1.0",
-        "pull-pushable": "2.2.0",
-        "pull-reader": "1.2.9"
+        "pull-cat": "^1.1.9",
+        "pull-pair": "~1.1.0",
+        "pull-pushable": "^2.0.0",
+        "pull-reader": "^1.2.3"
       }
     },
     "pull-length-prefixed": {
@@ -13922,10 +13925,10 @@
       "resolved": "https://registry.npmjs.org/pull-length-prefixed/-/pull-length-prefixed-1.3.0.tgz",
       "integrity": "sha512-FkxMYPNUSFjEDEXuS6MAaKwagQAN0sonifeC+NeutQmgXy+WBdPOtPzDT1dyT69Io1wzraZ+GzXAbBGnFcjdFQ==",
       "requires": {
-        "pull-pushable": "2.2.0",
-        "pull-reader": "1.2.9",
-        "safe-buffer": "5.1.1",
-        "varint": "5.0.0"
+        "pull-pushable": "^2.0.1",
+        "pull-reader": "^1.2.9",
+        "safe-buffer": "^5.0.1",
+        "varint": "^5.0.0"
       }
     },
     "pull-many": {
@@ -13933,7 +13936,7 @@
       "resolved": "https://registry.npmjs.org/pull-many/-/pull-many-1.0.8.tgz",
       "integrity": "sha1-Pa3ZttFWxUVyG9qNAAPdjqoGKT4=",
       "requires": {
-        "pull-stream": "3.6.7"
+        "pull-stream": "^3.4.5"
       }
     },
     "pull-ndjson": {
@@ -13941,9 +13944,9 @@
       "resolved": "https://registry.npmjs.org/pull-ndjson/-/pull-ndjson-0.1.1.tgz",
       "integrity": "sha1-gx4GutmqbFxevBKol+Og4V1J4H4=",
       "requires": {
-        "pull-split": "0.2.0",
-        "pull-stream": "3.6.7",
-        "pull-stringify": "1.2.2"
+        "pull-split": "^0.2.0",
+        "pull-stream": "^3.4.5",
+        "pull-stringify": "^1.2.2"
       }
     },
     "pull-pair": {
@@ -13956,7 +13959,7 @@
       "resolved": "https://registry.npmjs.org/pull-paramap/-/pull-paramap-1.2.2.tgz",
       "integrity": "sha1-UaQZPOnI1yFdla2tReK824STsjo=",
       "requires": {
-        "looper": "4.0.0"
+        "looper": "^4.0.0"
       },
       "dependencies": {
         "looper": {
@@ -13986,8 +13989,8 @@
       "resolved": "https://registry.npmjs.org/pull-sort/-/pull-sort-1.0.1.tgz",
       "integrity": "sha1-qKsMcMhvRTQ8mszJOfxCdprT3G0=",
       "requires": {
-        "pull-defer": "0.2.2",
-        "pull-stream": "3.6.7"
+        "pull-defer": "^0.2.2",
+        "pull-stream": "^3.6.0"
       }
     },
     "pull-split": {
@@ -13995,7 +13998,7 @@
       "resolved": "https://registry.npmjs.org/pull-split/-/pull-split-0.2.0.tgz",
       "integrity": "sha1-mW0ohTEFIgmoMTiK0NKB3zyCN5Y=",
       "requires": {
-        "pull-through": "1.0.18"
+        "pull-through": "~1.0.6"
       }
     },
     "pull-stream": {
@@ -14018,7 +14021,7 @@
       "resolved": "https://registry.npmjs.org/pull-through/-/pull-through-1.0.18.tgz",
       "integrity": "sha1-jdYjFCY+Wc9Qlur7sSeitu8xBzU=",
       "requires": {
-        "looper": "3.0.0"
+        "looper": "~3.0.0"
       }
     },
     "pull-traverse": {
@@ -14036,9 +14039,9 @@
       "resolved": "https://registry.npmjs.org/pull-write/-/pull-write-1.1.4.tgz",
       "integrity": "sha1-3d6jFJO0j2douEooHQHrO1Mf4Lg=",
       "requires": {
-        "looper": "4.0.0",
-        "pull-cat": "1.1.11",
-        "pull-stream": "3.6.7"
+        "looper": "^4.0.0",
+        "pull-cat": "^1.1.11",
+        "pull-stream": "^3.4.5"
       },
       "dependencies": {
         "looper": {
@@ -14053,9 +14056,9 @@
       "resolved": "https://registry.npmjs.org/pull-ws/-/pull-ws-3.3.1.tgz",
       "integrity": "sha512-kJodbLQT+oKjcRIQO+vQNw6xWBuEo7Kxp51VMOvb6cvPvHYA+aNLzm+NmkB/5dZwbuTRYGMal9QPvH52tzM1ZA==",
       "requires": {
-        "relative-url": "1.0.2",
-        "safe-buffer": "5.1.1",
-        "ws": "1.1.5"
+        "relative-url": "^1.0.2",
+        "safe-buffer": "^5.1.1",
+        "ws": "^1.1.0"
       },
       "dependencies": {
         "ultron": {
@@ -14068,8 +14071,8 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
           "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
           "requires": {
-            "options": "0.0.6",
-            "ultron": "1.0.2"
+            "options": ">=0.0.5",
+            "ultron": "1.0.x"
           }
         }
       }
@@ -14084,8 +14087,8 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
       "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
       "requires": {
-        "end-of-stream": "1.4.0",
-        "once": "1.4.0"
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "pumpify": {
@@ -14093,9 +14096,9 @@
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
       "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
       "requires": {
-        "duplexify": "3.5.1",
-        "inherits": "2.0.3",
-        "pump": "1.0.2"
+        "duplexify": "^3.1.2",
+        "inherits": "^2.0.1",
+        "pump": "^1.0.0"
       }
     },
     "punycode": {
@@ -14108,7 +14111,7 @@
       "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
       "integrity": "sha1-FZMdPNlnreUiBvUjqnMxrvfUOvc=",
       "requires": {
-        "bitcoin-ops": "1.4.1"
+        "bitcoin-ops": "^1.3.0"
       }
     },
     "q": {
@@ -14126,8 +14129,8 @@
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
       "requires": {
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       }
     },
     "querystring": {
@@ -14150,10 +14153,10 @@
       "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.2.tgz",
       "integrity": "sha512-Tudr3tPSPr64J+Fnr8hsNKbi5e2xueyLROmemOIsIsUIeX+WU7LtA22HWRRHr2gGasqxhah2NzFGe9N32eJkMg==",
       "requires": {
-        "clone": "2.1.1",
-        "deep-equal": "1.0.1",
-        "eventemitter3": "2.0.3",
-        "extend": "3.0.1",
+        "clone": "~2.1.1",
+        "deep-equal": "~1.0.1",
+        "eventemitter3": "~2.0.3",
+        "extend": "~3.0.1",
         "parchment": "1.1.0",
         "quill-delta": "3.6.1"
       },
@@ -14193,8 +14196,8 @@
           "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.1.tgz",
           "integrity": "sha512-jSD448mqyDevX0FhdjNppMLHl67vXEzZEDjQrtkfDXI6s6e3WJkJOZpYiVhqxLl4HcYNeAhFT+fhAeX8ef7Cew==",
           "requires": {
-            "deep-equal": "1.0.1",
-            "extend": "3.0.1",
+            "deep-equal": "^1.0.1",
+            "extend": "^3.0.1",
             "fast-diff": "1.1.1"
           }
         }
@@ -14205,8 +14208,8 @@
       "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.2.tgz",
       "integrity": "sha512-grWEQq9woEidPDogtDNxQKmy2LFf9zBC0EU/YTSw6TwKmMjtihTxdnPtPRfrqazB2MSJ7YdCWxmsJ7aQKRSEgg==",
       "requires": {
-        "deep-equal": "1.0.1",
-        "extend": "3.0.1",
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.1",
         "fast-diff": "1.1.2"
       }
     },
@@ -14221,7 +14224,7 @@
       "integrity": "sha1-DBO+C1tJtG921maSSNUnzysC/ic=",
       "dev": true,
       "requires": {
-        "performance-now": "2.1.0"
+        "performance-now": "^2.1.0"
       }
     },
     "railroad-diagrams": {
@@ -14237,7 +14240,7 @@
       "dev": true,
       "requires": {
         "discontinuous-range": "1.0.0",
-        "ret": "0.1.15"
+        "ret": "~0.1.10"
       }
     },
     "randomatic": {
@@ -14245,8 +14248,8 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -14254,7 +14257,7 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -14262,7 +14265,7 @@
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -14272,7 +14275,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -14282,7 +14285,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
       "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.0"
       }
     },
     "range-parser": {
@@ -14306,10 +14309,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
       "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
       "requires": {
-        "deep-extend": "0.4.2",
-        "ini": "1.3.4",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "~0.4.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       }
     },
     "react": {
@@ -14317,11 +14320,11 @@
       "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
       "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
       "requires": {
-        "create-react-class": "15.6.2",
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "create-react-class": "^15.6.0",
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.0",
+        "prop-types": "^15.5.10"
       }
     },
     "react-dev-utils": {
@@ -14341,7 +14344,7 @@
         "inquirer": "3.2.1",
         "is-root": "1.0.0",
         "opn": "5.1.0",
-        "react-error-overlay": "2.0.2",
+        "react-error-overlay": "^2.0.2",
         "recursive-readdir": "2.2.1",
         "shell-quote": "1.6.1",
         "sockjs-client": "1.1.4",
@@ -14364,9 +14367,9 @@
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
           "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
           }
         },
         "inquirer": {
@@ -14374,20 +14377,20 @@
           "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.1.tgz",
           "integrity": "sha512-QgW3eiPN8gpj/K5vVpHADJJgrrF0ho/dZGylikGX7iqAdRgC9FVKYKWFLx6hZDBFcOLEoSqINYrVPeFAeG/PdA==",
           "requires": {
-            "ansi-escapes": "2.0.0",
-            "chalk": "2.1.0",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "2.0.5",
-            "figures": "2.0.0",
-            "lodash": "4.17.4",
+            "ansi-escapes": "^2.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.0.4",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
             "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rx-lite": "4.0.8",
-            "rx-lite-aggregates": "4.0.8",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
+            "run-async": "^2.2.0",
+            "rx-lite": "^4.0.8",
+            "rx-lite-aggregates": "^4.0.8",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
           },
           "dependencies": {
             "chalk": {
@@ -14395,9 +14398,9 @@
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
               "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
               "requires": {
-                "ansi-styles": "3.2.0",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "4.4.0"
+                "ansi-styles": "^3.1.0",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^4.0.0"
               }
             },
             "strip-ansi": {
@@ -14405,7 +14408,7 @@
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -14420,8 +14423,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "strip-ansi": {
@@ -14429,7 +14432,7 @@
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -14441,10 +14444,10 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
       "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
       "requires": {
-        "fbjs": "0.8.16",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "fbjs": "^0.8.9",
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.0",
+        "prop-types": "^15.5.10"
       }
     },
     "react-error-overlay": {
@@ -14456,8 +14459,8 @@
         "babel-code-frame": "6.22.0",
         "babel-runtime": "6.26.0",
         "html-entities": "1.2.1",
-        "react": "15.6.2",
-        "react-dom": "15.6.2",
+        "react": "^15 || ^16",
+        "react-dom": "^15 || ^16",
         "settle-promise": "1.0.0",
         "source-map": "0.5.6"
       },
@@ -14467,9 +14470,9 @@
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
           "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
           }
         },
         "source-map": {
@@ -14484,13 +14487,13 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.2.0.tgz",
       "integrity": "sha512-DY6pjwRhdARE4TDw7XjxjZsbx9lKmIcyZoZ+SDO7SBJ1KUeWNxT22Kara2AC7u6/c2SYEHlEDLnzBCcNhLE8Vg==",
       "requires": {
-        "history": "4.7.2",
-        "hoist-non-react-statics": "2.3.1",
-        "invariant": "2.2.2",
-        "loose-envify": "1.3.1",
-        "path-to-regexp": "1.7.0",
-        "prop-types": "15.6.0",
-        "warning": "3.0.0"
+        "history": "^4.7.2",
+        "hoist-non-react-statics": "^2.3.0",
+        "invariant": "^2.2.2",
+        "loose-envify": "^1.3.1",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.5.4",
+        "warning": "^3.0.0"
       },
       "dependencies": {
         "hoist-non-react-statics": {
@@ -14503,7 +14506,7 @@
           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
           "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "isarray": {
@@ -14521,7 +14524,7 @@
           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "path-to-regexp": {
@@ -14537,7 +14540,7 @@
           "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
           "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         }
       }
@@ -14547,12 +14550,12 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.2.2.tgz",
       "integrity": "sha512-cHMFC1ZoLDfEaMFoKTjN7fry/oczMgRt5BKfMAkTu5zEuJvUiPp1J8d0eXSVTnBh6pxlbdqDhozunOOLtmKfPA==",
       "requires": {
-        "history": "4.7.2",
-        "invariant": "2.2.2",
-        "loose-envify": "1.3.1",
-        "prop-types": "15.6.0",
-        "react-router": "4.2.0",
-        "warning": "3.0.0"
+        "history": "^4.7.2",
+        "invariant": "^2.2.2",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.5.4",
+        "react-router": "^4.2.0",
+        "warning": "^3.0.0"
       },
       "dependencies": {
         "invariant": {
@@ -14560,7 +14563,7 @@
           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
           "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "js-tokens": {
@@ -14573,7 +14576,7 @@
           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "warning": {
@@ -14581,7 +14584,7 @@
           "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
           "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         }
       }
@@ -14591,7 +14594,7 @@
       "resolved": "https://registry.npmjs.org/react-router-hash-link/-/react-router-hash-link-1.1.1.tgz",
       "integrity": "sha1-c4DMeogJJD2UOFkkr1LcnSyfuqE=",
       "requires": {
-        "prop-types": "15.6.0"
+        "prop-types": "^15.6.0"
       }
     },
     "react-scripts": {
@@ -14604,14 +14607,14 @@
         "babel-eslint": "7.2.3",
         "babel-jest": "20.0.3",
         "babel-loader": "7.1.1",
-        "babel-preset-react-app": "3.0.3",
+        "babel-preset-react-app": "^3.0.2",
         "babel-runtime": "6.26.0",
         "case-sensitive-paths-webpack-plugin": "2.1.1",
         "chalk": "1.1.3",
         "css-loader": "0.28.4",
         "dotenv": "4.0.0",
         "eslint": "4.4.1",
-        "eslint-config-react-app": "2.0.1",
+        "eslint-config-react-app": "^2.0.0",
         "eslint-loader": "1.9.0",
         "eslint-plugin-flowtype": "2.35.0",
         "eslint-plugin-import": "2.7.0",
@@ -14627,7 +14630,7 @@
         "postcss-flexbugs-fixes": "3.2.0",
         "postcss-loader": "2.0.6",
         "promise": "8.0.1",
-        "react-dev-utils": "4.1.0",
+        "react-dev-utils": "^4.0.1",
         "style-loader": "0.18.2",
         "sw-precache-webpack-plugin": "0.11.4",
         "url-loader": "0.5.9",
@@ -14643,8 +14646,8 @@
       "integrity": "sha1-0DM0NPwsQ4CSaWyncNpe1IA376g=",
       "dev": true,
       "requires": {
-        "fbjs": "0.8.16",
-        "object-assign": "4.1.1"
+        "fbjs": "^0.8.9",
+        "object-assign": "^4.1.0"
       }
     },
     "read-all-stream": {
@@ -14652,8 +14655,8 @@
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
       "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
       "requires": {
-        "pinkie-promise": "2.0.1",
-        "readable-stream": "2.3.3"
+        "pinkie-promise": "^2.0.0",
+        "readable-stream": "^2.0.0"
       }
     },
     "read-cache": {
@@ -14661,7 +14664,7 @@
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.3.0"
       },
       "dependencies": {
         "pify": {
@@ -14676,9 +14679,9 @@
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "requires": {
-        "load-json-file": "2.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
       }
     },
     "read-pkg-up": {
@@ -14686,8 +14689,8 @@
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
       }
     },
     "readable-stream": {
@@ -14695,13 +14698,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -14709,10 +14712,10 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "recursive-readdir": {
@@ -14728,7 +14731,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.0.0"
           }
         }
       }
@@ -14738,8 +14741,8 @@
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "reduce-css-calc": {
@@ -14747,9 +14750,9 @@
       "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "requires": {
-        "balanced-match": "0.4.2",
-        "math-expression-evaluator": "1.2.17",
-        "reduce-function-call": "1.0.2"
+        "balanced-match": "^0.4.2",
+        "math-expression-evaluator": "^1.2.14",
+        "reduce-function-call": "^1.0.1"
       },
       "dependencies": {
         "balanced-match": {
@@ -14764,7 +14767,7 @@
       "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
       "requires": {
-        "balanced-match": "0.4.2"
+        "balanced-match": "^0.4.2"
       },
       "dependencies": {
         "balanced-match": {
@@ -14789,9 +14792,9 @@
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.7"
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
       }
     },
     "regex-cache": {
@@ -14799,7 +14802,7 @@
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "regexpu-core": {
@@ -14807,9 +14810,9 @@
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "requires": {
-        "regenerate": "1.3.3",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
       }
     },
     "registry-auth-token": {
@@ -14817,8 +14820,8 @@
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
       "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
       "requires": {
-        "rc": "1.2.1",
-        "safe-buffer": "5.1.1"
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
       }
     },
     "registry-url": {
@@ -14826,7 +14829,7 @@
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "requires": {
-        "rc": "1.2.1"
+        "rc": "^1.0.1"
       }
     },
     "regjsgen": {
@@ -14839,7 +14842,7 @@
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "requires": {
-        "jsesc": "0.5.0"
+        "jsesc": "~0.5.0"
       }
     },
     "rehype-parse": {
@@ -14847,9 +14850,9 @@
       "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-3.1.0.tgz",
       "integrity": "sha1-f1InpZej85/EuThkYWFTnERO5yg=",
       "requires": {
-        "hast-util-from-parse5": "1.1.0",
-        "parse5": "2.2.3",
-        "xtend": "4.0.1"
+        "hast-util-from-parse5": "^1.0.0",
+        "parse5": "^2.1.5",
+        "xtend": "^4.0.1"
       },
       "dependencies": {
         "parse5": {
@@ -14874,9 +14877,9 @@
       "resolved": "https://registry.npmjs.org/remark/-/remark-8.0.0.tgz",
       "integrity": "sha512-K0PTsaZvJlXTl9DN6qYlvjTkqSZBFELhROZMrblm2rB+085flN84nz4g/BscKRMqDvhzlK1oQ/xnWQumdeNZYw==",
       "requires": {
-        "remark-parse": "4.0.0",
-        "remark-stringify": "4.0.0",
-        "unified": "6.1.6"
+        "remark-parse": "^4.0.0",
+        "remark-stringify": "^4.0.0",
+        "unified": "^6.0.0"
       }
     },
     "remark-html": {
@@ -14884,10 +14887,10 @@
       "resolved": "https://registry.npmjs.org/remark-html/-/remark-html-6.0.1.tgz",
       "integrity": "sha1-UJTSxx95Qf2yroZbrHZid1fOCcE=",
       "requires": {
-        "hast-util-sanitize": "1.1.2",
-        "hast-util-to-html": "3.1.0",
-        "mdast-util-to-hast": "2.5.0",
-        "xtend": "4.0.1"
+        "hast-util-sanitize": "^1.0.0",
+        "hast-util-to-html": "^3.0.0",
+        "mdast-util-to-hast": "^2.1.1",
+        "xtend": "^4.0.1"
       }
     },
     "remark-html-katex": {
@@ -14895,11 +14898,11 @@
       "resolved": "https://registry.npmjs.org/remark-html-katex/-/remark-html-katex-1.1.0.tgz",
       "integrity": "sha512-+88jJsFCaiug875kIR/bOqdZd3QUC5YrTfIiB/+Izntj3Z1ZWhS/KuJPoRIvtuVTGUUTKaPe9/rMje7ENXtAPw==",
       "requires": {
-        "katex": "0.9.0",
-        "rehype-parse": "3.1.0",
-        "unified": "6.1.6",
-        "unist-util-position": "3.0.0",
-        "unist-util-visit": "1.3.0"
+        "katex": "^0.9.0",
+        "rehype-parse": "^3.0.0",
+        "unified": "^6.1.1",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
       }
     },
     "remark-math": {
@@ -14907,7 +14910,7 @@
       "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-1.0.3.tgz",
       "integrity": "sha512-kr/gqqrkwN56QbKFNXkCi13TlKvfxiPTLSrsu2jAiIfp8kMMF5KOkyvwvtwtFTyVsbD+WfqbfaadelJKsLfeeA==",
       "requires": {
-        "trim-trailing-lines": "1.1.1"
+        "trim-trailing-lines": "^1.1.0"
       }
     },
     "remark-parse": {
@@ -14915,21 +14918,21 @@
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-4.0.0.tgz",
       "integrity": "sha512-XZgICP2gJ1MHU7+vQaRM+VA9HEL3X253uwUM/BGgx3iv6TH2B3bF3B8q00DKcyP9YrJV+/7WOWEWBFF/u8cIsw==",
       "requires": {
-        "collapse-white-space": "1.0.4",
-        "is-alphabetical": "1.0.2",
-        "is-decimal": "1.0.2",
-        "is-whitespace-character": "1.0.2",
-        "is-word-character": "1.0.2",
-        "markdown-escapes": "1.0.2",
-        "parse-entities": "1.1.2",
-        "repeat-string": "1.6.1",
-        "state-toggle": "1.0.1",
+        "collapse-white-space": "^1.0.2",
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "is-word-character": "^1.0.0",
+        "markdown-escapes": "^1.0.0",
+        "parse-entities": "^1.0.2",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
         "trim": "0.0.1",
-        "trim-trailing-lines": "1.1.1",
-        "unherit": "1.1.1",
-        "unist-util-remove-position": "1.1.2",
-        "vfile-location": "2.0.2",
-        "xtend": "4.0.1"
+        "trim-trailing-lines": "^1.0.0",
+        "unherit": "^1.0.4",
+        "unist-util-remove-position": "^1.0.0",
+        "vfile-location": "^2.0.0",
+        "xtend": "^4.0.1"
       }
     },
     "remark-stringify": {
@@ -14937,20 +14940,20 @@
       "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-4.0.0.tgz",
       "integrity": "sha512-xLuyKTnuQer3ke9hkU38SUYLiTmS078QOnoFavztmbt/pAJtNSkNtFgR0U//uCcmG0qnyxao+PDuatQav46F1w==",
       "requires": {
-        "ccount": "1.0.3",
-        "is-alphanumeric": "1.0.0",
-        "is-decimal": "1.0.2",
-        "is-whitespace-character": "1.0.2",
-        "longest-streak": "2.0.2",
-        "markdown-escapes": "1.0.2",
-        "markdown-table": "1.1.2",
-        "mdast-util-compact": "1.0.1",
-        "parse-entities": "1.1.2",
-        "repeat-string": "1.6.1",
-        "state-toggle": "1.0.1",
-        "stringify-entities": "1.3.2",
-        "unherit": "1.1.1",
-        "xtend": "4.0.1"
+        "ccount": "^1.0.0",
+        "is-alphanumeric": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "longest-streak": "^2.0.1",
+        "markdown-escapes": "^1.0.0",
+        "markdown-table": "^1.1.0",
+        "mdast-util-compact": "^1.0.0",
+        "parse-entities": "^1.0.2",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "stringify-entities": "^1.0.1",
+        "unherit": "^1.0.4",
+        "xtend": "^4.0.1"
       }
     },
     "remove-trailing-separator": {
@@ -14963,11 +14966,11 @@
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
       "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
       "requires": {
-        "css-select": "1.2.0",
-        "dom-converter": "0.1.4",
-        "htmlparser2": "3.3.0",
-        "strip-ansi": "3.0.1",
-        "utila": "0.3.3"
+        "css-select": "^1.1.0",
+        "dom-converter": "~0.1",
+        "htmlparser2": "~3.3.0",
+        "strip-ansi": "^3.0.0",
+        "utila": "~0.3"
       },
       "dependencies": {
         "domhandler": {
@@ -14975,7 +14978,7 @@
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
           "requires": {
-            "domelementtype": "1.3.0"
+            "domelementtype": "1"
           }
         },
         "domutils": {
@@ -14983,7 +14986,7 @@
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
           "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
           "requires": {
-            "domelementtype": "1.3.0"
+            "domelementtype": "1"
           }
         },
         "htmlparser2": {
@@ -14991,10 +14994,10 @@
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
           "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
           "requires": {
-            "domelementtype": "1.3.0",
-            "domhandler": "2.1.0",
-            "domutils": "1.1.6",
-            "readable-stream": "1.0.34"
+            "domelementtype": "1",
+            "domhandler": "2.1",
+            "domutils": "1.1",
+            "readable-stream": "1.0"
           }
         },
         "isarray": {
@@ -15007,10 +15010,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
             "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
+            "string_decoder": "~0.10.x"
           }
         },
         "string_decoder": {
@@ -15040,7 +15043,7 @@
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "replace-ext": {
@@ -15053,28 +15056,28 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "require-directory": {
@@ -15097,8 +15100,8 @@
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "requires-port": {
@@ -15111,7 +15114,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
       "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-dir": {
@@ -15119,8 +15122,8 @@
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
       "requires": {
-        "expand-tilde": "2.0.2",
-        "global-modules": "1.0.0"
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
       }
     },
     "resolve-from": {
@@ -15133,8 +15136,8 @@
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "ret": {
@@ -15148,7 +15151,7 @@
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -15161,8 +15164,8 @@
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
       "requires": {
-        "hash-base": "2.0.2",
-        "inherits": "2.0.3"
+        "hash-base": "^2.0.0",
+        "inherits": "^2.0.1"
       }
     },
     "rlp": {
@@ -15175,7 +15178,7 @@
       "resolved": "https://registry.npmjs.org/rsa-pem-to-jwk/-/rsa-pem-to-jwk-1.1.3.tgz",
       "integrity": "sha1-JF52vbfnI0z+58oDLTG1TDj6uY4=",
       "requires": {
-        "object-assign": "2.1.1",
+        "object-assign": "^2.0.0",
         "rsa-unpack": "0.0.6"
       },
       "dependencies": {
@@ -15191,7 +15194,7 @@
       "resolved": "https://registry.npmjs.org/rsa-unpack/-/rsa-unpack-0.0.6.tgz",
       "integrity": "sha1-9Q69VqYoN45jHylxYQJs6atO3bo=",
       "requires": {
-        "optimist": "0.3.7"
+        "optimist": "~0.3.5"
       },
       "dependencies": {
         "optimist": {
@@ -15199,7 +15202,7 @@
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
           "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
           "requires": {
-            "wordwrap": "0.0.3"
+            "wordwrap": "~0.0.2"
           }
         },
         "wordwrap": {
@@ -15215,8 +15218,8 @@
       "integrity": "sha512-1xVsEpnaiNsz4zVJFTUyiOk4UG1UiLOGGaA75J/McWlpgRa+Ze5S2bnPQS0tcLbbo3vhFvIX5mpC0V1pBLzaoQ==",
       "dev": true,
       "requires": {
-        "lodash.flattendeep": "4.4.0",
-        "nearley": "2.11.0"
+        "lodash.flattendeep": "^4.4.0",
+        "nearley": "^2.7.10"
       }
     },
     "run-async": {
@@ -15224,7 +15227,7 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "run-queue": {
@@ -15232,7 +15235,7 @@
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
       "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
       "requires": {
-        "aproba": "1.2.0"
+        "aproba": "^1.1.1"
       }
     },
     "rx-lite": {
@@ -15245,7 +15248,7 @@
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
       "requires": {
-        "rx-lite": "4.0.8"
+        "rx-lite": "*"
       }
     },
     "safe-buffer": {
@@ -15258,13 +15261,13 @@
       "resolved": "https://registry.npmjs.org/sane/-/sane-1.6.0.tgz",
       "integrity": "sha1-lhDEUjB6E10pwf3+JUcDQYDEZ3U=",
       "requires": {
-        "anymatch": "1.3.2",
-        "exec-sh": "0.2.1",
-        "fb-watchman": "1.9.2",
-        "minimatch": "3.0.4",
-        "minimist": "1.2.0",
-        "walker": "1.0.7",
-        "watch": "0.10.0"
+        "anymatch": "^1.3.0",
+        "exec-sh": "^0.2.0",
+        "fb-watchman": "^1.8.0",
+        "minimatch": "^3.0.2",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5",
+        "watch": "~0.10.0"
       },
       "dependencies": {
         "bser": {
@@ -15272,7 +15275,7 @@
           "resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
           "integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
           "requires": {
-            "node-int64": "0.4.0"
+            "node-int64": "^0.4.0"
           }
         },
         "fb-watchman": {
@@ -15290,7 +15293,7 @@
       "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.1.tgz",
       "integrity": "sha1-YS2hyWRz+gLczaktzVtKsWSmdyo=",
       "requires": {
-        "truncate-utf8-bytes": "1.0.2"
+        "truncate-utf8-bytes": "^1.0.0"
       }
     },
     "sax": {
@@ -15303,7 +15306,7 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
       "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
       "requires": {
-        "ajv": "5.2.3"
+        "ajv": "^5.0.0"
       }
     },
     "secp256k1": {
@@ -15311,14 +15314,14 @@
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
       "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
       "requires": {
-        "bindings": "1.3.0",
-        "bip66": "1.1.5",
-        "bn.js": "4.11.8",
-        "create-hash": "1.1.3",
-        "drbg.js": "1.0.1",
-        "elliptic": "6.4.0",
-        "nan": "2.7.0",
-        "safe-buffer": "5.1.1"
+        "bindings": "^1.2.1",
+        "bip66": "^1.1.3",
+        "bn.js": "^4.11.3",
+        "create-hash": "^1.1.2",
+        "drbg.js": "^1.0.1",
+        "elliptic": "^6.2.3",
+        "nan": "^2.2.1",
+        "safe-buffer": "^5.1.0"
       }
     },
     "select-hose": {
@@ -15349,7 +15352,7 @@
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "requires": {
-        "semver": "5.4.1"
+        "semver": "^5.0.3"
       }
     },
     "send": {
@@ -15358,18 +15361,18 @@
       "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.1",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.2",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.3.1"
       },
       "dependencies": {
         "debug": {
@@ -15392,13 +15395,13 @@
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
       "requires": {
-        "accepts": "1.3.4",
+        "accepts": "~1.3.4",
         "batch": "0.6.1",
         "debug": "2.6.9",
-        "escape-html": "1.0.3",
-        "http-errors": "1.6.2",
-        "mime-types": "2.1.17",
-        "parseurl": "1.3.2"
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
       },
       "dependencies": {
         "accepts": {
@@ -15406,7 +15409,7 @@
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
           "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
           "requires": {
-            "mime-types": "2.1.17",
+            "mime-types": "~2.1.16",
             "negotiator": "0.6.1"
           }
         },
@@ -15425,9 +15428,9 @@
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
       "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
       "requires": {
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.1"
       }
     },
@@ -15466,7 +15469,7 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
       "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "^2.0.1"
       }
     },
     "sha3": {
@@ -15489,7 +15492,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -15502,10 +15505,10 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "requires": {
-        "array-filter": "0.0.1",
-        "array-map": "0.0.0",
-        "array-reduce": "0.0.0",
-        "jsonify": "0.0.0"
+        "array-filter": "~0.0.0",
+        "array-map": "~0.0.0",
+        "array-reduce": "~0.0.0",
+        "jsonify": "~0.0.0"
       }
     },
     "shellwords": {
@@ -15518,8 +15521,8 @@
       "resolved": "https://registry.npmjs.org/shot/-/shot-3.4.2.tgz",
       "integrity": "sha1-Hlw/bysmZJrcQvfrNQIUpaApHWc=",
       "requires": {
-        "hoek": "4.2.0",
-        "joi": "10.6.0"
+        "hoek": "4.x.x",
+        "joi": "10.x.x"
       },
       "dependencies": {
         "joi": {
@@ -15527,10 +15530,10 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
           "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
           "requires": {
-            "hoek": "4.2.0",
-            "isemail": "2.2.1",
-            "items": "2.1.1",
-            "topo": "2.0.2"
+            "hoek": "4.x.x",
+            "isemail": "2.x.x",
+            "items": "2.x.x",
+            "topo": "2.x.x"
           }
         }
       }
@@ -15545,7 +15548,7 @@
       "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
       "integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
       "requires": {
-        "varint": "5.0.0"
+        "varint": "~5.0.0"
       }
     },
     "simple-concat": {
@@ -15558,9 +15561,9 @@
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
       "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
       "requires": {
-        "decompress-response": "3.3.0",
-        "once": "1.4.0",
-        "simple-concat": "1.0.0"
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "simple-peer": {
@@ -15568,11 +15571,11 @@
       "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-8.5.0.tgz",
       "integrity": "sha512-L901ld7sqQv7c8ehThEZGIDqgBrTC1iJLlcqFlqtH3YhUb+S8uBjdQpzaJGth+NkSoWNJSsXjNyWbzaM99cMQg==",
       "requires": {
-        "debug": "3.1.0",
-        "get-browser-rtc": "1.0.2",
-        "inherits": "2.0.3",
-        "randombytes": "2.0.5",
-        "readable-stream": "2.3.6"
+        "debug": "^3.1.0",
+        "get-browser-rtc": "^1.0.0",
+        "inherits": "^2.0.1",
+        "randombytes": "^2.0.3",
+        "readable-stream": "^2.3.4"
       },
       "dependencies": {
         "process-nextick-args": {
@@ -15585,13 +15588,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -15599,7 +15602,7 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -15614,7 +15617,7 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "is-fullwidth-code-point": "^2.0.0"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -15639,7 +15642,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
       "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "socket.io": {
@@ -15647,12 +15650,12 @@
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.0.tgz",
       "integrity": "sha512-KS+3CNWWNtLbVN5j0/B+1hjxRzey+oTK6ejpAOoxMZis6aXeB8cUtfuvjHl97tuZx+t/qD/VyqFMjuzu2Js6uQ==",
       "requires": {
-        "debug": "3.1.0",
-        "engine.io": "3.2.0",
-        "has-binary2": "1.0.2",
-        "socket.io-adapter": "1.1.1",
+        "debug": "~3.1.0",
+        "engine.io": "~3.2.0",
+        "has-binary2": "~1.0.2",
+        "socket.io-adapter": "~1.1.0",
         "socket.io-client": "2.1.0",
-        "socket.io-parser": "3.2.0"
+        "socket.io-parser": "~3.2.0"
       }
     },
     "socket.io-adapter": {
@@ -15669,15 +15672,15 @@
         "base64-arraybuffer": "0.1.5",
         "component-bind": "1.0.0",
         "component-emitter": "1.2.1",
-        "debug": "3.1.0",
-        "engine.io-client": "3.2.1",
-        "has-binary2": "1.0.2",
+        "debug": "~3.1.0",
+        "engine.io-client": "~3.2.0",
+        "has-binary2": "~1.0.2",
         "has-cors": "1.1.0",
         "indexof": "0.0.1",
         "object-component": "0.0.3",
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
-        "socket.io-parser": "3.2.0",
+        "socket.io-parser": "~3.2.0",
         "to-array": "0.1.4"
       }
     },
@@ -15687,7 +15690,7 @@
       "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
       "requires": {
         "component-emitter": "1.2.1",
-        "debug": "3.1.0",
+        "debug": "~3.1.0",
         "isarray": "2.0.1"
       },
       "dependencies": {
@@ -15704,9 +15707,9 @@
       "integrity": "sha512-lcC2se3iAS33xYGnTDSzYW9P4RPVEgcqACCH7Mawy+2go0Wmx3y72PXGv7KI6Vz1YFcOz7np58FqOnZ/iUCbdg==",
       "requires": {
         "data-queue": "0.0.3",
-        "debug": "3.1.0",
-        "pull-stream": "3.6.7",
-        "uuid": "3.2.1"
+        "debug": "^3.1.0",
+        "pull-stream": "^3.6.2",
+        "uuid": "^3.2.1"
       },
       "dependencies": {
         "uuid": {
@@ -15721,8 +15724,8 @@
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
       "integrity": "sha1-2bKJMWyn33dZXvKZ4HXw+TfrQgc=",
       "requires": {
-        "faye-websocket": "0.10.0",
-        "uuid": "2.0.3"
+        "faye-websocket": "^0.10.0",
+        "uuid": "^2.0.2"
       },
       "dependencies": {
         "faye-websocket": {
@@ -15730,7 +15733,7 @@
           "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
           "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
           "requires": {
-            "websocket-driver": "0.7.0"
+            "websocket-driver": ">=0.5.1"
           }
         },
         "uuid": {
@@ -15745,12 +15748,12 @@
       "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
       "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
       "requires": {
-        "debug": "2.6.9",
+        "debug": "^2.6.6",
         "eventsource": "0.1.6",
-        "faye-websocket": "0.11.1",
-        "inherits": "2.0.3",
-        "json3": "3.3.2",
-        "url-parse": "1.1.9"
+        "faye-websocket": "~0.11.0",
+        "inherits": "^2.0.1",
+        "json3": "^3.3.2",
+        "url-parse": "^1.1.8"
       },
       "dependencies": {
         "debug": {
@@ -15768,7 +15771,7 @@
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "requires": {
-        "is-plain-obj": "1.1.0"
+        "is-plain-obj": "^1.0.0"
       }
     },
     "source-list-map": {
@@ -15786,7 +15789,7 @@
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       }
     },
     "space-separated-tokens": {
@@ -15807,7 +15810,7 @@
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -15825,12 +15828,12 @@
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
       "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
       "requires": {
-        "debug": "2.6.9",
-        "handle-thing": "1.2.5",
-        "http-deceiver": "1.2.7",
-        "safe-buffer": "5.1.1",
-        "select-hose": "2.0.0",
-        "spdy-transport": "2.0.20"
+        "debug": "^2.6.8",
+        "handle-thing": "^1.2.5",
+        "http-deceiver": "^1.2.7",
+        "safe-buffer": "^5.0.1",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^2.0.18"
       },
       "dependencies": {
         "debug": {
@@ -15848,13 +15851,13 @@
       "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz",
       "integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
       "requires": {
-        "debug": "2.6.9",
-        "detect-node": "2.0.3",
-        "hpack.js": "2.1.6",
-        "obuf": "1.1.1",
-        "readable-stream": "2.3.3",
-        "safe-buffer": "5.1.1",
-        "wbuf": "1.7.2"
+        "debug": "^2.6.8",
+        "detect-node": "^2.0.3",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.1",
+        "readable-stream": "^2.2.9",
+        "safe-buffer": "^5.0.1",
+        "wbuf": "^1.7.2"
       },
       "dependencies": {
         "debug": {
@@ -15872,7 +15875,7 @@
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "split2": {
@@ -15880,7 +15883,7 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
       "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
       "requires": {
-        "through2": "2.0.3"
+        "through2": "^2.0.2"
       }
     },
     "sprintf-js": {
@@ -15893,14 +15896,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.0",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "ssri": {
@@ -15908,7 +15911,7 @@
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.0.0.tgz",
       "integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.0"
       }
     },
     "stable": {
@@ -15922,15 +15925,15 @@
       "integrity": "sha512-JURZ+85ExKLQULckDFijdX5WHzN6RC7fgiZNSV4jFQVo+3tPoQGHyBrGekye/yf0aOfb4210EM5qPNlc2cRh4w==",
       "dev": true,
       "requires": {
-        "eslint": "3.19.0",
+        "eslint": "~3.19.0",
         "eslint-config-standard": "10.2.1",
         "eslint-config-standard-jsx": "4.0.2",
-        "eslint-plugin-import": "2.2.0",
-        "eslint-plugin-node": "4.2.3",
-        "eslint-plugin-promise": "3.5.0",
-        "eslint-plugin-react": "6.10.3",
-        "eslint-plugin-standard": "3.0.1",
-        "standard-engine": "7.0.0"
+        "eslint-plugin-import": "~2.2.0",
+        "eslint-plugin-node": "~4.2.2",
+        "eslint-plugin-promise": "~3.5.0",
+        "eslint-plugin-react": "~6.10.0",
+        "eslint-plugin-standard": "~3.0.1",
+        "standard-engine": "~7.0.0"
       },
       "dependencies": {
         "acorn": {
@@ -15945,7 +15948,7 @@
           "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
           "dev": true,
           "requires": {
-            "acorn": "3.3.0"
+            "acorn": "^3.0.4"
           },
           "dependencies": {
             "acorn": {
@@ -15962,8 +15965,8 @@
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "ajv-keywords": {
@@ -15996,7 +15999,7 @@
           "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
           "dev": true,
           "requires": {
-            "sprintf-js": "1.0.3"
+            "sprintf-js": "~1.0.2"
           }
         },
         "array-union": {
@@ -16005,7 +16008,7 @@
           "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
           "dev": true,
           "requires": {
-            "array-uniq": "1.0.3"
+            "array-uniq": "^1.0.1"
           }
         },
         "array-uniq": {
@@ -16020,8 +16023,8 @@
           "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
           "dev": true,
           "requires": {
-            "define-properties": "1.1.2",
-            "es-abstract": "1.8.2"
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.7.0"
           }
         },
         "arrify": {
@@ -16036,9 +16039,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "balanced-match": {
@@ -16053,7 +16056,7 @@
           "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
           "dev": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -16069,7 +16072,7 @@
           "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
           "dev": true,
           "requires": {
-            "callsites": "0.2.0"
+            "callsites": "^0.2.0"
           }
         },
         "callsites": {
@@ -16084,11 +16087,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "circular-json": {
@@ -16103,7 +16106,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "1.0.1"
+            "restore-cursor": "^1.0.1"
           }
         },
         "cli-width": {
@@ -16136,9 +16139,9 @@
           "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.3",
-            "typedarray": "0.0.6"
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         },
         "contains-path": {
@@ -16159,7 +16162,7 @@
           "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
           "dev": true,
           "requires": {
-            "es5-ext": "0.10.30"
+            "es5-ext": "^0.10.9"
           }
         },
         "debug": {
@@ -16189,8 +16192,8 @@
           "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
           "dev": true,
           "requires": {
-            "foreach": "2.0.5",
-            "object-keys": "1.0.11"
+            "foreach": "^2.0.5",
+            "object-keys": "^1.0.8"
           }
         },
         "deglob": {
@@ -16199,12 +16202,12 @@
           "integrity": "sha1-TUSr4W7zLHebSXK9FBqAMlApoUo=",
           "dev": true,
           "requires": {
-            "find-root": "1.1.0",
-            "glob": "7.1.2",
-            "ignore": "3.3.5",
-            "pkg-config": "1.1.1",
-            "run-parallel": "1.1.6",
-            "uniq": "1.0.1"
+            "find-root": "^1.0.0",
+            "glob": "^7.0.5",
+            "ignore": "^3.0.9",
+            "pkg-config": "^1.1.0",
+            "run-parallel": "^1.1.2",
+            "uniq": "^1.0.1"
           }
         },
         "del": {
@@ -16213,13 +16216,13 @@
           "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
           "dev": true,
           "requires": {
-            "globby": "5.0.0",
-            "is-path-cwd": "1.0.0",
-            "is-path-in-cwd": "1.0.0",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "rimraf": "2.6.2"
+            "globby": "^5.0.0",
+            "is-path-cwd": "^1.0.0",
+            "is-path-in-cwd": "^1.0.0",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "rimraf": "^2.2.8"
           }
         },
         "doctrine": {
@@ -16228,8 +16231,8 @@
           "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
         },
         "error-ex": {
@@ -16238,7 +16241,7 @@
           "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
           "dev": true,
           "requires": {
-            "is-arrayish": "0.2.1"
+            "is-arrayish": "^0.2.1"
           }
         },
         "es-abstract": {
@@ -16247,11 +16250,11 @@
           "integrity": "sha512-dvhwFL3yjQxNNsOWx6exMlaDrRHCRGMQlnx5lsXDCZ/J7G/frgIIl94zhZSp/galVAYp7VzPi1OrAHta89/yGQ==",
           "dev": true,
           "requires": {
-            "es-to-primitive": "1.1.1",
-            "function-bind": "1.1.1",
-            "has": "1.0.1",
-            "is-callable": "1.1.3",
-            "is-regex": "1.0.4"
+            "es-to-primitive": "^1.1.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.1",
+            "is-callable": "^1.1.3",
+            "is-regex": "^1.0.4"
           }
         },
         "es-to-primitive": {
@@ -16260,9 +16263,9 @@
           "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
           "dev": true,
           "requires": {
-            "is-callable": "1.1.3",
-            "is-date-object": "1.0.1",
-            "is-symbol": "1.0.1"
+            "is-callable": "^1.1.1",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.1"
           }
         },
         "es5-ext": {
@@ -16271,8 +16274,8 @@
           "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
           "dev": true,
           "requires": {
-            "es6-iterator": "2.0.1",
-            "es6-symbol": "3.1.1"
+            "es6-iterator": "2",
+            "es6-symbol": "~3.1"
           }
         },
         "es6-iterator": {
@@ -16281,9 +16284,9 @@
           "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
           "dev": true,
           "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.30",
-            "es6-symbol": "3.1.1"
+            "d": "1",
+            "es5-ext": "^0.10.14",
+            "es6-symbol": "^3.1"
           }
         },
         "es6-map": {
@@ -16292,12 +16295,12 @@
           "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
           "dev": true,
           "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.30",
-            "es6-iterator": "2.0.1",
-            "es6-set": "0.1.5",
-            "es6-symbol": "3.1.1",
-            "event-emitter": "0.3.5"
+            "d": "1",
+            "es5-ext": "~0.10.14",
+            "es6-iterator": "~2.0.1",
+            "es6-set": "~0.1.5",
+            "es6-symbol": "~3.1.1",
+            "event-emitter": "~0.3.5"
           }
         },
         "es6-set": {
@@ -16306,11 +16309,11 @@
           "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
           "dev": true,
           "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.30",
-            "es6-iterator": "2.0.1",
+            "d": "1",
+            "es5-ext": "~0.10.14",
+            "es6-iterator": "~2.0.1",
             "es6-symbol": "3.1.1",
-            "event-emitter": "0.3.5"
+            "event-emitter": "~0.3.5"
           }
         },
         "es6-symbol": {
@@ -16319,8 +16322,8 @@
           "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
           "dev": true,
           "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.30"
+            "d": "1",
+            "es5-ext": "~0.10.14"
           }
         },
         "es6-weak-map": {
@@ -16329,10 +16332,10 @@
           "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
           "dev": true,
           "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.30",
-            "es6-iterator": "2.0.1",
-            "es6-symbol": "3.1.1"
+            "d": "1",
+            "es5-ext": "^0.10.14",
+            "es6-iterator": "^2.0.1",
+            "es6-symbol": "^3.1.1"
           }
         },
         "escape-string-regexp": {
@@ -16347,10 +16350,10 @@
           "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
           "dev": true,
           "requires": {
-            "es6-map": "0.1.5",
-            "es6-weak-map": "2.0.2",
-            "esrecurse": "4.2.0",
-            "estraverse": "4.2.0"
+            "es6-map": "^0.1.3",
+            "es6-weak-map": "^2.0.1",
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
           }
         },
         "eslint": {
@@ -16359,41 +16362,41 @@
           "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "chalk": "1.1.3",
-            "concat-stream": "1.6.0",
-            "debug": "2.6.9",
-            "doctrine": "2.0.0",
-            "escope": "3.6.0",
-            "espree": "3.5.1",
-            "esquery": "1.0.0",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "file-entry-cache": "2.0.0",
-            "glob": "7.1.2",
-            "globals": "9.18.0",
-            "ignore": "3.3.5",
-            "imurmurhash": "0.1.4",
-            "inquirer": "0.12.0",
-            "is-my-json-valid": "2.16.1",
-            "is-resolvable": "1.0.0",
-            "js-yaml": "3.10.0",
-            "json-stable-stringify": "1.0.1",
-            "levn": "0.3.0",
-            "lodash": "4.17.4",
-            "mkdirp": "0.5.1",
-            "natural-compare": "1.4.0",
-            "optionator": "0.8.2",
-            "path-is-inside": "1.0.2",
-            "pluralize": "1.2.1",
-            "progress": "1.1.8",
-            "require-uncached": "1.0.3",
-            "shelljs": "0.7.8",
-            "strip-bom": "3.0.0",
-            "strip-json-comments": "2.0.1",
-            "table": "3.8.3",
-            "text-table": "0.2.0",
-            "user-home": "2.0.0"
+            "babel-code-frame": "^6.16.0",
+            "chalk": "^1.1.3",
+            "concat-stream": "^1.5.2",
+            "debug": "^2.1.1",
+            "doctrine": "^2.0.0",
+            "escope": "^3.6.0",
+            "espree": "^3.4.0",
+            "esquery": "^1.0.0",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "glob": "^7.0.3",
+            "globals": "^9.14.0",
+            "ignore": "^3.2.0",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^0.12.0",
+            "is-my-json-valid": "^2.10.0",
+            "is-resolvable": "^1.0.0",
+            "js-yaml": "^3.5.1",
+            "json-stable-stringify": "^1.0.0",
+            "levn": "^0.3.0",
+            "lodash": "^4.0.0",
+            "mkdirp": "^0.5.0",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.1",
+            "pluralize": "^1.2.1",
+            "progress": "^1.1.8",
+            "require-uncached": "^1.0.2",
+            "shelljs": "^0.7.5",
+            "strip-bom": "^3.0.0",
+            "strip-json-comments": "~2.0.1",
+            "table": "^3.7.8",
+            "text-table": "~0.2.0",
+            "user-home": "^2.0.0"
           }
         },
         "eslint-config-standard": {
@@ -16414,9 +16417,9 @@
           "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "object-assign": "4.1.1",
-            "resolve": "1.4.0"
+            "debug": "^2.2.0",
+            "object-assign": "^4.0.1",
+            "resolve": "^1.1.6"
           }
         },
         "eslint-module-utils": {
@@ -16425,8 +16428,8 @@
           "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
           "dev": true,
           "requires": {
-            "debug": "2.6.9",
-            "pkg-dir": "1.0.0"
+            "debug": "^2.6.8",
+            "pkg-dir": "^1.0.0"
           }
         },
         "eslint-plugin-import": {
@@ -16435,16 +16438,16 @@
           "integrity": "sha1-crowb60wXWfEgWNIpGmaQimsi04=",
           "dev": true,
           "requires": {
-            "builtin-modules": "1.1.1",
-            "contains-path": "0.1.0",
-            "debug": "2.6.9",
+            "builtin-modules": "^1.1.1",
+            "contains-path": "^0.1.0",
+            "debug": "^2.2.0",
             "doctrine": "1.5.0",
-            "eslint-import-resolver-node": "0.2.3",
-            "eslint-module-utils": "2.1.1",
-            "has": "1.0.1",
-            "lodash.cond": "4.5.2",
-            "minimatch": "3.0.4",
-            "pkg-up": "1.0.0"
+            "eslint-import-resolver-node": "^0.2.0",
+            "eslint-module-utils": "^2.0.0",
+            "has": "^1.0.1",
+            "lodash.cond": "^4.3.0",
+            "minimatch": "^3.0.3",
+            "pkg-up": "^1.0.0"
           },
           "dependencies": {
             "doctrine": {
@@ -16453,8 +16456,8 @@
               "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
               "dev": true,
               "requires": {
-                "esutils": "2.0.2",
-                "isarray": "1.0.0"
+                "esutils": "^2.0.2",
+                "isarray": "^1.0.0"
               }
             }
           }
@@ -16465,10 +16468,10 @@
           "integrity": "sha512-vIUQPuwbVYdz/CYnlTLsJrRy7iXHQjdEe5wz0XhhdTym3IInM/zZLlPf9nZ2mThsH0QcsieCOWs2vOeCy/22LQ==",
           "dev": true,
           "requires": {
-            "ignore": "3.3.5",
-            "minimatch": "3.0.4",
-            "object-assign": "4.1.1",
-            "resolve": "1.4.0",
+            "ignore": "^3.0.11",
+            "minimatch": "^3.0.2",
+            "object-assign": "^4.0.1",
+            "resolve": "^1.1.7",
             "semver": "5.3.0"
           }
         },
@@ -16484,11 +16487,11 @@
           "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
           "dev": true,
           "requires": {
-            "array.prototype.find": "2.0.4",
-            "doctrine": "1.5.0",
-            "has": "1.0.1",
-            "jsx-ast-utils": "1.4.1",
-            "object.assign": "4.0.4"
+            "array.prototype.find": "^2.0.1",
+            "doctrine": "^1.2.2",
+            "has": "^1.0.1",
+            "jsx-ast-utils": "^1.3.4",
+            "object.assign": "^4.0.4"
           },
           "dependencies": {
             "doctrine": {
@@ -16497,8 +16500,8 @@
               "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
               "dev": true,
               "requires": {
-                "esutils": "2.0.2",
-                "isarray": "1.0.0"
+                "esutils": "^2.0.2",
+                "isarray": "^1.0.0"
               }
             }
           }
@@ -16515,8 +16518,8 @@
           "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
           "dev": true,
           "requires": {
-            "acorn": "5.1.2",
-            "acorn-jsx": "3.0.1"
+            "acorn": "^5.1.1",
+            "acorn-jsx": "^3.0.0"
           }
         },
         "esprima": {
@@ -16531,7 +16534,7 @@
           "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
           "dev": true,
           "requires": {
-            "estraverse": "4.2.0"
+            "estraverse": "^4.0.0"
           }
         },
         "esrecurse": {
@@ -16540,8 +16543,8 @@
           "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
           "dev": true,
           "requires": {
-            "estraverse": "4.2.0",
-            "object-assign": "4.1.1"
+            "estraverse": "^4.1.0",
+            "object-assign": "^4.0.1"
           }
         },
         "estraverse": {
@@ -16562,8 +16565,8 @@
           "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
           "dev": true,
           "requires": {
-            "d": "1.0.0",
-            "es5-ext": "0.10.30"
+            "d": "1",
+            "es5-ext": "~0.10.14"
           }
         },
         "exit-hook": {
@@ -16584,8 +16587,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "1.0.5",
-            "object-assign": "4.1.1"
+            "escape-string-regexp": "^1.0.5",
+            "object-assign": "^4.1.0"
           }
         },
         "file-entry-cache": {
@@ -16594,8 +16597,8 @@
           "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
           "dev": true,
           "requires": {
-            "flat-cache": "1.2.2",
-            "object-assign": "4.1.1"
+            "flat-cache": "^1.2.1",
+            "object-assign": "^4.0.1"
           }
         },
         "find-root": {
@@ -16610,8 +16613,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "flat-cache": {
@@ -16620,10 +16623,10 @@
           "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
           "dev": true,
           "requires": {
-            "circular-json": "0.3.3",
-            "del": "2.2.2",
-            "graceful-fs": "4.1.11",
-            "write": "0.2.1"
+            "circular-json": "^0.3.1",
+            "del": "^2.0.2",
+            "graceful-fs": "^4.1.2",
+            "write": "^0.2.1"
           }
         },
         "foreach": {
@@ -16656,7 +16659,7 @@
           "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
           "dev": true,
           "requires": {
-            "is-property": "1.0.2"
+            "is-property": "^1.0.0"
           }
         },
         "get-stdin": {
@@ -16671,12 +16674,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "globals": {
@@ -16691,12 +16694,12 @@
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "graceful-fs": {
@@ -16711,7 +16714,7 @@
           "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
           "dev": true,
           "requires": {
-            "function-bind": "1.1.1"
+            "function-bind": "^1.0.2"
           }
         },
         "has-ansi": {
@@ -16720,7 +16723,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "ignore": {
@@ -16741,8 +16744,8 @@
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -16757,19 +16760,19 @@
           "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
           "dev": true,
           "requires": {
-            "ansi-escapes": "1.4.0",
-            "ansi-regex": "2.1.1",
-            "chalk": "1.1.3",
-            "cli-cursor": "1.0.2",
-            "cli-width": "2.2.0",
-            "figures": "1.7.0",
-            "lodash": "4.17.4",
-            "readline2": "1.0.1",
-            "run-async": "0.1.0",
-            "rx-lite": "3.1.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "through": "2.3.8"
+            "ansi-escapes": "^1.1.0",
+            "ansi-regex": "^2.0.0",
+            "chalk": "^1.0.0",
+            "cli-cursor": "^1.0.1",
+            "cli-width": "^2.0.0",
+            "figures": "^1.3.5",
+            "lodash": "^4.3.0",
+            "readline2": "^1.0.1",
+            "run-async": "^0.1.0",
+            "rx-lite": "^3.1.2",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.0",
+            "through": "^2.3.6"
           }
         },
         "interpret": {
@@ -16802,7 +16805,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-my-json-valid": {
@@ -16811,10 +16814,10 @@
           "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
           "dev": true,
           "requires": {
-            "generate-function": "2.0.0",
-            "generate-object-property": "1.2.0",
-            "jsonpointer": "4.0.1",
-            "xtend": "4.0.1"
+            "generate-function": "^2.0.0",
+            "generate-object-property": "^1.1.0",
+            "jsonpointer": "^4.0.0",
+            "xtend": "^4.0.0"
           }
         },
         "is-path-cwd": {
@@ -16829,7 +16832,7 @@
           "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
           "dev": true,
           "requires": {
-            "is-path-inside": "1.0.0"
+            "is-path-inside": "^1.0.0"
           }
         },
         "is-path-inside": {
@@ -16838,7 +16841,7 @@
           "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
           "dev": true,
           "requires": {
-            "path-is-inside": "1.0.2"
+            "path-is-inside": "^1.0.1"
           }
         },
         "is-property": {
@@ -16853,7 +16856,7 @@
           "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
           "dev": true,
           "requires": {
-            "has": "1.0.1"
+            "has": "^1.0.1"
           }
         },
         "is-resolvable": {
@@ -16862,7 +16865,7 @@
           "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
           "dev": true,
           "requires": {
-            "tryit": "1.0.3"
+            "tryit": "^1.0.1"
           }
         },
         "is-symbol": {
@@ -16889,8 +16892,8 @@
           "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "json-stable-stringify": {
@@ -16899,7 +16902,7 @@
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           }
         },
         "jsonify": {
@@ -16926,8 +16929,8 @@
           "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
           "dev": true,
           "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
           }
         },
         "load-json-file": {
@@ -16936,10 +16939,10 @@
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "locate-path": {
@@ -16948,8 +16951,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
           },
           "dependencies": {
             "path-exists": {
@@ -16978,7 +16981,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -17038,9 +17041,9 @@
           "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
           "dev": true,
           "requires": {
-            "define-properties": "1.1.2",
-            "function-bind": "1.1.1",
-            "object-keys": "1.0.11"
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.0",
+            "object-keys": "^1.0.10"
           }
         },
         "once": {
@@ -17049,7 +17052,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "onetime": {
@@ -17064,12 +17067,12 @@
           "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
           "dev": true,
           "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "2.0.6",
-            "levn": "0.3.0",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "1.0.0"
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.4",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "wordwrap": "~1.0.0"
           }
         },
         "os-homedir": {
@@ -17090,7 +17093,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "1.1.0"
+            "p-limit": "^1.1.0"
           }
         },
         "parse-json": {
@@ -17099,7 +17102,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "path-exists": {
@@ -17108,7 +17111,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-is-absolute": {
@@ -17147,7 +17150,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "pkg-conf": {
@@ -17156,8 +17159,8 @@
           "integrity": "sha1-BxyHZQQDvM+5xif1h1G/5HwGcnk=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "load-json-file": "2.0.0"
+            "find-up": "^2.0.0",
+            "load-json-file": "^2.0.0"
           },
           "dependencies": {
             "find-up": {
@@ -17166,7 +17169,7 @@
               "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
               "dev": true,
               "requires": {
-                "locate-path": "2.0.0"
+                "locate-path": "^2.0.0"
               }
             }
           }
@@ -17177,9 +17180,9 @@
           "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
           "dev": true,
           "requires": {
-            "debug-log": "1.0.1",
-            "find-root": "1.1.0",
-            "xtend": "4.0.1"
+            "debug-log": "^1.0.0",
+            "find-root": "^1.0.0",
+            "xtend": "^4.0.1"
           }
         },
         "pkg-dir": {
@@ -17188,7 +17191,7 @@
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           }
         },
         "pkg-up": {
@@ -17197,7 +17200,7 @@
           "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
           "dev": true,
           "requires": {
-            "find-up": "1.1.2"
+            "find-up": "^1.0.0"
           }
         },
         "pluralize": {
@@ -17230,13 +17233,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "readline2": {
@@ -17245,8 +17248,8 @@
           "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
             "mute-stream": "0.0.5"
           }
         },
@@ -17256,7 +17259,7 @@
           "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
           "dev": true,
           "requires": {
-            "resolve": "1.4.0"
+            "resolve": "^1.1.6"
           }
         },
         "require-uncached": {
@@ -17265,8 +17268,8 @@
           "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
           "dev": true,
           "requires": {
-            "caller-path": "0.1.0",
-            "resolve-from": "1.0.1"
+            "caller-path": "^0.1.0",
+            "resolve-from": "^1.0.0"
           }
         },
         "resolve": {
@@ -17275,7 +17278,7 @@
           "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
           "dev": true,
           "requires": {
-            "path-parse": "1.0.5"
+            "path-parse": "^1.0.5"
           }
         },
         "resolve-from": {
@@ -17290,8 +17293,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "1.1.1",
-            "onetime": "1.1.0"
+            "exit-hook": "^1.0.0",
+            "onetime": "^1.0.0"
           }
         },
         "rimraf": {
@@ -17300,7 +17303,7 @@
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "run-async": {
@@ -17309,7 +17312,7 @@
           "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
           "dev": true,
           "requires": {
-            "once": "1.4.0"
+            "once": "^1.3.0"
           }
         },
         "run-parallel": {
@@ -17342,9 +17345,9 @@
           "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
           "dev": true,
           "requires": {
-            "glob": "7.1.2",
-            "interpret": "1.0.4",
-            "rechoir": "0.6.2"
+            "glob": "^7.0.0",
+            "interpret": "^1.0.0",
+            "rechoir": "^0.6.2"
           }
         },
         "slice-ansi": {
@@ -17365,10 +17368,10 @@
           "integrity": "sha1-67d7nI/CyBZf+jU72Rug3/Qa9pA=",
           "dev": true,
           "requires": {
-            "deglob": "2.1.0",
-            "get-stdin": "5.0.1",
-            "minimist": "1.2.0",
-            "pkg-conf": "2.0.0"
+            "deglob": "^2.1.0",
+            "get-stdin": "^5.0.1",
+            "minimist": "^1.1.0",
+            "pkg-conf": "^2.0.0"
           },
           "dependencies": {
             "minimist": {
@@ -17385,9 +17388,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -17396,7 +17399,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
@@ -17405,7 +17408,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -17432,12 +17435,12 @@
           "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
           "dev": true,
           "requires": {
-            "ajv": "4.11.8",
-            "ajv-keywords": "1.5.1",
-            "chalk": "1.1.3",
-            "lodash": "4.17.4",
+            "ajv": "^4.7.0",
+            "ajv-keywords": "^1.0.0",
+            "chalk": "^1.1.1",
+            "lodash": "^4.0.0",
             "slice-ansi": "0.0.4",
-            "string-width": "2.1.1"
+            "string-width": "^2.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -17458,8 +17461,8 @@
               "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
               "dev": true,
               "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
               }
             },
             "strip-ansi": {
@@ -17468,7 +17471,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -17497,7 +17500,7 @@
           "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
           "dev": true,
           "requires": {
-            "prelude-ls": "1.1.2"
+            "prelude-ls": "~1.1.2"
           }
         },
         "typedarray": {
@@ -17518,7 +17521,7 @@
           "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.2"
+            "os-homedir": "^1.0.0"
           }
         },
         "util-deprecate": {
@@ -17545,7 +17548,7 @@
           "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
           "dev": true,
           "requires": {
-            "mkdirp": "0.5.1"
+            "mkdirp": "^0.5.1"
           }
         },
         "xtend": {
@@ -17566,12 +17569,12 @@
       "resolved": "https://registry.npmjs.org/statehood/-/statehood-5.0.3.tgz",
       "integrity": "sha512-YrPrCt10t3ImH/JMO5szSwX7sCm8HoqVl3VFLOa9EZ1g/qJx/ZmMhN+2uzPPB/vaU6hpkJpXxcBWsgIkkG+MXA==",
       "requires": {
-        "boom": "5.2.0",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "iron": "4.0.5",
-        "items": "2.1.1",
-        "joi": "10.6.0"
+        "boom": "5.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "iron": "4.x.x",
+        "items": "2.x.x",
+        "joi": "10.x.x"
       },
       "dependencies": {
         "joi": {
@@ -17579,10 +17582,10 @@
           "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
           "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
           "requires": {
-            "hoek": "4.2.0",
-            "isemail": "2.2.1",
-            "items": "2.1.1",
-            "topo": "2.0.2"
+            "hoek": "4.x.x",
+            "isemail": "2.x.x",
+            "items": "2.x.x",
+            "topo": "2.x.x"
           }
         }
       }
@@ -17597,8 +17600,8 @@
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "stream-each": {
@@ -17606,8 +17609,8 @@
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
       "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
       "requires": {
-        "end-of-stream": "1.4.0",
-        "stream-shift": "1.0.0"
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
       }
     },
     "stream-http": {
@@ -17615,11 +17618,11 @@
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
       "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
       "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.2.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "stream-shift": {
@@ -17632,8 +17635,8 @@
       "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz",
       "integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
       "requires": {
-        "looper": "3.0.0",
-        "pull-stream": "3.6.7"
+        "looper": "^3.0.0",
+        "pull-stream": "^3.2.3"
       }
     },
     "streamifier": {
@@ -17656,7 +17659,7 @@
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
       "integrity": "sha1-VpcPscOFWOnnC3KL894mmsRa36w=",
       "requires": {
-        "strip-ansi": "3.0.1"
+        "strip-ansi": "^3.0.0"
       }
     },
     "string-width": {
@@ -17664,9 +17667,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -17674,7 +17677,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringify-entities": {
@@ -17682,10 +17685,10 @@
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-1.3.2.tgz",
       "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
       "requires": {
-        "character-entities-html4": "1.1.2",
-        "character-entities-legacy": "1.1.2",
-        "is-alphanumerical": "1.0.2",
-        "is-hexadecimal": "1.0.2"
+        "character-entities-html4": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
       }
     },
     "stringstream": {
@@ -17698,7 +17701,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -17724,7 +17727,7 @@
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
@@ -17737,8 +17740,8 @@
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.18.2.tgz",
       "integrity": "sha512-WPpJPZGUxWYHWIUMNNOYqql7zh85zGmr84FdTVWq52WTIkqlW9xSxD3QYWi/T31cqn9UNSsietVEgGn2aaSCzw==",
       "requires": {
-        "loader-utils": "1.1.0",
-        "schema-utils": "0.3.0"
+        "loader-utils": "^1.0.2",
+        "schema-utils": "^0.3.0"
       }
     },
     "subtext": {
@@ -17746,11 +17749,11 @@
       "resolved": "https://registry.npmjs.org/subtext/-/subtext-5.0.0.tgz",
       "integrity": "sha512-2nXG1G1V+K64Z20cQII7k0s38J2DSycMXBLMAk9RXUFG0uAkAbLSVoa88croX9VhTdBCJbLAe9g6LmzKwpJhhQ==",
       "requires": {
-        "boom": "5.2.0",
-        "content": "3.0.7",
-        "hoek": "4.2.0",
-        "pez": "2.1.5",
-        "wreck": "12.5.1"
+        "boom": "5.x.x",
+        "content": "3.x.x",
+        "hoek": "4.x.x",
+        "pez": "2.x.x",
+        "wreck": "12.x.x"
       }
     },
     "supports-color": {
@@ -17758,7 +17761,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
       "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
       "requires": {
-        "has-flag": "2.0.0"
+        "has-flag": "^2.0.0"
       }
     },
     "svgo": {
@@ -17766,13 +17769,13 @@
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
       "requires": {
-        "coa": "1.0.4",
-        "colors": "1.1.2",
-        "csso": "2.3.2",
-        "js-yaml": "3.7.0",
-        "mkdirp": "0.5.1",
-        "sax": "1.2.4",
-        "whet.extend": "0.9.9"
+        "coa": "~1.0.1",
+        "colors": "~1.1.2",
+        "csso": "~2.3.1",
+        "js-yaml": "~3.7.0",
+        "mkdirp": "~0.5.1",
+        "sax": "~1.2.1",
+        "whet.extend": "~0.9.9"
       },
       "dependencies": {
         "colors": {
@@ -17787,16 +17790,16 @@
       "resolved": "https://registry.npmjs.org/sw-precache/-/sw-precache-5.2.0.tgz",
       "integrity": "sha512-sKctdX+5hUxkqJ/1DM88ubQ+QRvyw7CnxWdk909N2DgvxMqc1gcQFrwL7zpVc87wFmCA/OvRQd0iMC2XdFopYg==",
       "requires": {
-        "dom-urls": "1.1.0",
-        "es6-promise": "4.1.1",
-        "glob": "7.1.2",
-        "lodash.defaults": "4.2.0",
-        "lodash.template": "4.4.0",
-        "meow": "3.7.0",
-        "mkdirp": "0.5.1",
-        "pretty-bytes": "4.0.2",
-        "sw-toolbox": "3.6.0",
-        "update-notifier": "1.0.3"
+        "dom-urls": "^1.1.0",
+        "es6-promise": "^4.0.5",
+        "glob": "^7.1.1",
+        "lodash.defaults": "^4.2.0",
+        "lodash.template": "^4.4.0",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "pretty-bytes": "^4.0.2",
+        "sw-toolbox": "^3.4.0",
+        "update-notifier": "^1.0.3"
       },
       "dependencies": {
         "ansi-align": {
@@ -17804,7 +17807,7 @@
           "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
           "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.1"
           }
         },
         "boxen": {
@@ -17812,15 +17815,15 @@
           "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
           "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
           "requires": {
-            "ansi-align": "1.1.0",
-            "camelcase": "2.1.1",
-            "chalk": "1.1.3",
-            "cli-boxes": "1.0.0",
-            "filled-array": "1.1.0",
-            "object-assign": "4.1.1",
-            "repeating": "2.0.1",
-            "string-width": "1.0.2",
-            "widest-line": "1.0.0"
+            "ansi-align": "^1.1.0",
+            "camelcase": "^2.1.0",
+            "chalk": "^1.1.1",
+            "cli-boxes": "^1.0.0",
+            "filled-array": "^1.0.0",
+            "object-assign": "^4.0.1",
+            "repeating": "^2.0.0",
+            "string-width": "^1.0.1",
+            "widest-line": "^1.0.0"
           }
         },
         "camelcase": {
@@ -17833,15 +17836,15 @@
           "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
           "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
           "requires": {
-            "dot-prop": "3.0.0",
-            "graceful-fs": "4.1.11",
-            "mkdirp": "0.5.1",
-            "object-assign": "4.1.1",
-            "os-tmpdir": "1.0.2",
-            "osenv": "0.1.4",
-            "uuid": "2.0.3",
-            "write-file-atomic": "1.3.4",
-            "xdg-basedir": "2.0.0"
+            "dot-prop": "^3.0.0",
+            "graceful-fs": "^4.1.2",
+            "mkdirp": "^0.5.0",
+            "object-assign": "^4.0.1",
+            "os-tmpdir": "^1.0.0",
+            "osenv": "^0.1.0",
+            "uuid": "^2.0.1",
+            "write-file-atomic": "^1.1.2",
+            "xdg-basedir": "^2.0.0"
           }
         },
         "dot-prop": {
@@ -17849,7 +17852,7 @@
           "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
           "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
           "requires": {
-            "is-obj": "1.0.1"
+            "is-obj": "^1.0.0"
           }
         },
         "got": {
@@ -17857,21 +17860,21 @@
           "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
           "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
           "requires": {
-            "create-error-class": "3.0.2",
-            "duplexer2": "0.1.4",
-            "is-redirect": "1.0.0",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.0",
-            "node-status-codes": "1.0.0",
-            "object-assign": "4.1.1",
-            "parse-json": "2.2.0",
-            "pinkie-promise": "2.0.1",
-            "read-all-stream": "3.1.0",
-            "readable-stream": "2.3.3",
-            "timed-out": "3.1.3",
-            "unzip-response": "1.0.2",
-            "url-parse-lax": "1.0.0"
+            "create-error-class": "^3.0.1",
+            "duplexer2": "^0.1.4",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "node-status-codes": "^1.0.0",
+            "object-assign": "^4.0.1",
+            "parse-json": "^2.1.0",
+            "pinkie-promise": "^2.0.0",
+            "read-all-stream": "^3.0.0",
+            "readable-stream": "^2.0.5",
+            "timed-out": "^3.0.0",
+            "unzip-response": "^1.0.2",
+            "url-parse-lax": "^1.0.0"
           }
         },
         "latest-version": {
@@ -17879,7 +17882,7 @@
           "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
           "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
           "requires": {
-            "package-json": "2.4.0"
+            "package-json": "^2.0.0"
           }
         },
         "package-json": {
@@ -17887,10 +17890,10 @@
           "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
           "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
           "requires": {
-            "got": "5.7.1",
-            "registry-auth-token": "3.3.1",
-            "registry-url": "3.1.0",
-            "semver": "5.4.1"
+            "got": "^5.0.0",
+            "registry-auth-token": "^3.0.1",
+            "registry-url": "^3.0.3",
+            "semver": "^5.1.0"
           }
         },
         "timed-out": {
@@ -17903,14 +17906,14 @@
           "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
           "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
           "requires": {
-            "boxen": "0.6.0",
-            "chalk": "1.1.3",
-            "configstore": "2.1.0",
-            "is-npm": "1.0.0",
-            "latest-version": "2.0.0",
-            "lazy-req": "1.1.0",
-            "semver-diff": "2.1.0",
-            "xdg-basedir": "2.0.0"
+            "boxen": "^0.6.0",
+            "chalk": "^1.0.0",
+            "configstore": "^2.0.0",
+            "is-npm": "^1.0.0",
+            "latest-version": "^2.0.0",
+            "lazy-req": "^1.1.0",
+            "semver-diff": "^2.0.0",
+            "xdg-basedir": "^2.0.0"
           }
         },
         "uuid": {
@@ -17923,9 +17926,9 @@
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
           "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
           }
         },
         "xdg-basedir": {
@@ -17933,7 +17936,7 @@
           "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
           "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
           "requires": {
-            "os-homedir": "1.0.2"
+            "os-homedir": "^1.0.0"
           }
         }
       }
@@ -17943,9 +17946,9 @@
       "resolved": "https://registry.npmjs.org/sw-precache-webpack-plugin/-/sw-precache-webpack-plugin-0.11.4.tgz",
       "integrity": "sha1-ppUBflTu1XVVFJOlGdwdqNotxeA=",
       "requires": {
-        "del": "2.2.2",
-        "sw-precache": "5.2.0",
-        "uglify-js": "3.1.3"
+        "del": "^2.2.2",
+        "sw-precache": "^5.1.1",
+        "uglify-js": "^3.0.13"
       }
     },
     "sw-toolbox": {
@@ -17953,8 +17956,8 @@
       "resolved": "https://registry.npmjs.org/sw-toolbox/-/sw-toolbox-3.6.0.tgz",
       "integrity": "sha1-Jt8dHHA0hljk3qKIQxkUm3sxg7U=",
       "requires": {
-        "path-to-regexp": "1.7.0",
-        "serviceworker-cache-polyfill": "4.0.0"
+        "path-to-regexp": "^1.0.1",
+        "serviceworker-cache-polyfill": "^4.0.0"
       }
     },
     "symbol-tree": {
@@ -17967,12 +17970,12 @@
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
       "requires": {
-        "ajv": "5.2.3",
-        "ajv-keywords": "2.1.0",
-        "chalk": "2.1.0",
-        "lodash": "4.17.4",
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -17985,9 +17988,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
           "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "is-fullwidth-code-point": {
@@ -18000,8 +18003,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -18009,7 +18012,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -18039,10 +18042,10 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.2.tgz",
       "integrity": "sha512-LdknWjPEiZC1nOBwhv0JBzfJBGPJar08dZg2rwZe0ZTLQoRGEzgrl7vF3qUEkCHpI/wN9e7RyCuDhMsJUCLPPQ==",
       "requires": {
-        "chownr": "1.0.1",
-        "mkdirp": "0.5.1",
-        "pump": "1.0.2",
-        "tar-stream": "1.6.0"
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
       }
     },
     "tar-stream": {
@@ -18050,13 +18053,13 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.0.tgz",
       "integrity": "sha512-lh2iAPG/BHNmN6WB9Ybdynk9rEJ5GD/dy4zscHmVlwa1dq2tpE+BH78i5vjYwYVWEaOXGBjzxr89aVACF17Cpw==",
       "requires": {
-        "bl": "1.2.2",
-        "buffer-alloc": "1.1.0",
-        "end-of-stream": "1.4.0",
-        "fs-constants": "1.0.0",
-        "readable-stream": "2.3.3",
-        "to-buffer": "1.1.1",
-        "xtend": "4.0.1"
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.1.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.0.0",
+        "to-buffer": "^1.1.0",
+        "xtend": "^4.0.0"
       }
     },
     "tdigest": {
@@ -18072,8 +18075,8 @@
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
       "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
       "requires": {
-        "os-tmpdir": "1.0.2",
-        "rimraf": "2.2.8"
+        "os-tmpdir": "^1.0.0",
+        "rimraf": "~2.2.6"
       }
     },
     "term-size": {
@@ -18081,7 +18084,7 @@
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "requires": {
-        "execa": "0.7.0"
+        "execa": "^0.7.0"
       }
     },
     "test-exclude": {
@@ -18089,11 +18092,11 @@
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
       "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
       "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "2.3.11",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "require-main-filename": "1.0.1"
+        "arrify": "^1.0.1",
+        "micromatch": "^2.3.11",
+        "object-assign": "^4.1.0",
+        "read-pkg-up": "^1.0.1",
+        "require-main-filename": "^1.0.1"
       },
       "dependencies": {
         "find-up": {
@@ -18101,8 +18104,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "load-json-file": {
@@ -18110,11 +18113,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "path-exists": {
@@ -18122,7 +18125,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -18130,9 +18133,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pify": {
@@ -18145,9 +18148,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -18155,8 +18158,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "strip-bom": {
@@ -18164,7 +18167,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -18189,8 +18192,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.3.3",
-        "xtend": "4.0.1"
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
       }
     },
     "thunky": {
@@ -18203,7 +18206,7 @@
       "resolved": "https://registry.npmjs.org/time-cache/-/time-cache-0.3.0.tgz",
       "integrity": "sha1-7Q388P2kXNyV+9YB/agw6/G9XYs=",
       "requires": {
-        "lodash.throttle": "4.1.1"
+        "lodash.throttle": "^4.1.1"
       }
     },
     "time-stamp": {
@@ -18226,7 +18229,7 @@
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
       "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
       "requires": {
-        "setimmediate": "1.0.5"
+        "setimmediate": "^1.0.4"
       }
     },
     "tmp": {
@@ -18234,7 +18237,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "tmpl": {
@@ -18267,7 +18270,7 @@
       "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "toposort": {
@@ -18280,7 +18283,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       },
       "dependencies": {
         "punycode": {
@@ -18335,7 +18338,7 @@
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
       "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
       "requires": {
-        "utf8-byte-length": "1.0.4"
+        "utf8-byte-length": "^1.0.1"
       }
     },
     "tryit": {
@@ -18353,7 +18356,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -18367,7 +18370,7 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-is": {
@@ -18376,7 +18379,7 @@
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.17"
+        "mime-types": "~2.1.15"
       }
     },
     "typedarray": {
@@ -18404,8 +18407,8 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.1.3.tgz",
       "integrity": "sha512-5ZUOgufCHjN2mBBLfz63UtWTP6va2sSzBpNCM+/iqI6RnPzEhANmB0EKiKBYdQbc3v7KeomXJ2DJx0Xq9gvUvA==",
       "requires": {
-        "commander": "2.11.0",
-        "source-map": "0.5.7"
+        "commander": "~2.11.0",
+        "source-map": "~0.5.1"
       }
     },
     "uglify-to-browserify": {
@@ -18419,13 +18422,13 @@
       "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.0.1.tgz",
       "integrity": "sha512-3IJhab8Xq7s6XqoPiVFuDpijefJsIrzACT4ggDErSxJAsB9GLDyuWpN7vuX4Lslu/nzIRz2NyXNX/fRMOgqRFw==",
       "requires": {
-        "cacache": "10.0.0",
-        "find-cache-dir": "1.0.0",
-        "schema-utils": "0.3.0",
-        "source-map": "0.5.7",
-        "uglify-es": "3.1.9",
-        "webpack-sources": "1.0.1",
-        "worker-farm": "1.5.0"
+        "cacache": "^10.0.0",
+        "find-cache-dir": "^1.0.0",
+        "schema-utils": "^0.3.0",
+        "source-map": "^0.5.6",
+        "uglify-es": "^3.1.3",
+        "webpack-sources": "^1.0.1",
+        "worker-farm": "^1.4.1"
       },
       "dependencies": {
         "uglify-es": {
@@ -18433,8 +18436,8 @@
           "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.1.9.tgz",
           "integrity": "sha512-wVSiJKHDgDDFmxTVVvnbAH6IpamAFHYDI+5JvwPdaqIMnk8kRTX2JKwq1Fx7gb2+Jj5Dus8kzvIpKkWOMNU51w==",
           "requires": {
-            "commander": "2.11.0",
-            "source-map": "0.6.1"
+            "commander": "~2.11.0",
+            "source-map": "~0.6.1"
           },
           "dependencies": {
             "source-map": {
@@ -18462,8 +18465,8 @@
       "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.1.tgz",
       "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
       "requires": {
-        "inherits": "2.0.3",
-        "xtend": "4.0.1"
+        "inherits": "^2.0.1",
+        "xtend": "^4.0.1"
       }
     },
     "unified": {
@@ -18471,13 +18474,13 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-6.1.6.tgz",
       "integrity": "sha512-pW2f82bCIo2ifuIGYcV12fL96kMMYgw7JKVEgh7ODlrM9rj6vXSY3BV+H6lCcv1ksxynFf582hwWLnA1qRFy4w==",
       "requires": {
-        "bail": "1.0.3",
-        "extend": "3.0.1",
-        "is-plain-obj": "1.1.0",
-        "trough": "1.0.2",
-        "vfile": "2.3.0",
-        "x-is-function": "1.0.4",
-        "x-is-string": "0.1.0"
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^1.1.0",
+        "trough": "^1.0.0",
+        "vfile": "^2.0.0",
+        "x-is-function": "^1.0.4",
+        "x-is-string": "^0.1.0"
       }
     },
     "uniq": {
@@ -18490,7 +18493,7 @@
       "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
       "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
       "requires": {
-        "macaddress": "0.2.8"
+        "macaddress": "^0.2.8"
       }
     },
     "uniqs": {
@@ -18503,7 +18506,7 @@
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
       "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
       "requires": {
-        "unique-slug": "2.0.0"
+        "unique-slug": "^2.0.0"
       }
     },
     "unique-slug": {
@@ -18511,7 +18514,7 @@
       "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
       "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
       "requires": {
-        "imurmurhash": "0.1.4"
+        "imurmurhash": "^0.1.4"
       }
     },
     "unique-string": {
@@ -18519,7 +18522,7 @@
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "requires": {
-        "crypto-random-string": "1.0.0"
+        "crypto-random-string": "^1.0.0"
       }
     },
     "unist-builder": {
@@ -18527,7 +18530,7 @@
       "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-1.0.2.tgz",
       "integrity": "sha1-jDuZA+9kvPsRfdfPal2Y/Bs7J7Y=",
       "requires": {
-        "object-assign": "4.1.1"
+        "object-assign": "^4.1.0"
       }
     },
     "unist-util-generated": {
@@ -18545,7 +18548,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-1.1.2.tgz",
       "integrity": "sha512-GRi04yhng1WqBf5RBzPkOtWAadcZS2gvuOgNn/cyJBYNxtTuyYqTKN0eg4rC1YJwGnzrqfRB3dSKm8cNCjNirg==",
       "requires": {
-        "array-iterate": "1.1.2"
+        "array-iterate": "^1.0.0"
       }
     },
     "unist-util-position": {
@@ -18558,7 +18561,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz",
       "integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
       "requires": {
-        "unist-util-visit": "1.3.0"
+        "unist-util-visit": "^1.1.0"
       }
     },
     "unist-util-stringify-position": {
@@ -18571,7 +18574,7 @@
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.3.0.tgz",
       "integrity": "sha512-9ntYcxPFtl44gnwXrQKZ5bMqXMY0ZHzUpqMFiU4zcc8mmf/jzYm8GhYgezuUlX4cJIM1zIDYaO6fG/fI+L6iiQ==",
       "requires": {
-        "unist-util-is": "2.1.2"
+        "unist-util-is": "^2.1.1"
       }
     },
     "universalify": {
@@ -18594,16 +18597,16 @@
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
       "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "requires": {
-        "boxen": "1.3.0",
-        "chalk": "2.4.1",
-        "configstore": "3.1.2",
-        "import-lazy": "2.1.0",
-        "is-ci": "1.0.10",
-        "is-installed-globally": "0.1.0",
-        "is-npm": "1.0.0",
-        "latest-version": "3.1.0",
-        "semver-diff": "2.1.0",
-        "xdg-basedir": "3.0.0"
+        "boxen": "^1.2.1",
+        "chalk": "^2.0.1",
+        "configstore": "^3.0.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^1.0.10",
+        "is-installed-globally": "^0.1.0",
+        "is-npm": "^1.0.0",
+        "latest-version": "^3.0.0",
+        "semver-diff": "^2.0.0",
+        "xdg-basedir": "^3.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -18611,7 +18614,7 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -18619,9 +18622,9 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "has-flag": {
@@ -18634,7 +18637,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -18670,8 +18673,8 @@
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
       "integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
       "requires": {
-        "loader-utils": "1.1.0",
-        "mime": "1.3.6"
+        "loader-utils": "^1.0.2",
+        "mime": "1.3.x"
       }
     },
     "url-parse": {
@@ -18679,8 +18682,8 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
       "integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
       "requires": {
-        "querystringify": "1.0.0",
-        "requires-port": "1.0.0"
+        "querystringify": "~1.0.0",
+        "requires-port": "1.0.x"
       },
       "dependencies": {
         "querystringify": {
@@ -18695,7 +18698,7 @@
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "requires": {
-        "prepend-http": "1.0.4"
+        "prepend-http": "^1.0.1"
       }
     },
     "utf8-byte-length": {
@@ -18743,8 +18746,8 @@
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "varint": {
@@ -18757,7 +18760,7 @@
       "resolved": "https://registry.npmjs.org/varint-decoder/-/varint-decoder-0.1.1.tgz",
       "integrity": "sha1-YT1i8HHX51dqIO/RbvTB4zWg3f0=",
       "requires": {
-        "varint": "5.0.0"
+        "varint": "^5.0.0"
       }
     },
     "varuint-bitcoin": {
@@ -18765,7 +18768,7 @@
       "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
       "integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.1.1"
       }
     },
     "vary": {
@@ -18783,9 +18786,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vfile": {
@@ -18793,10 +18796,10 @@
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
       "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
       "requires": {
-        "is-buffer": "1.1.5",
+        "is-buffer": "^1.1.4",
         "replace-ext": "1.0.0",
-        "unist-util-stringify-position": "1.1.2",
-        "vfile-message": "1.0.0"
+        "unist-util-stringify-position": "^1.0.0",
+        "vfile-message": "^1.0.0"
       }
     },
     "vfile-location": {
@@ -18809,7 +18812,7 @@
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.0.0.tgz",
       "integrity": "sha512-HPREhzTOB/sNDc9/Mxf8w0FmHnThg5CRSJdR9VRFkD2riqYWs+fuXlj5z8mIpv2LrD7uU41+oPWFOL4Mjlf+dw==",
       "requires": {
-        "unist-util-stringify-position": "1.1.2"
+        "unist-util-stringify-position": "^1.1.1"
       }
     },
     "vise": {
@@ -18817,7 +18820,7 @@
       "resolved": "https://registry.npmjs.org/vise/-/vise-2.0.2.tgz",
       "integrity": "sha1-awjo+0y3bjpQzW3Q7DczjoEaDTk=",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "vm-browserify": {
@@ -18833,7 +18836,7 @@
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
-        "makeerror": "1.0.11"
+        "makeerror": "1.0.x"
       }
     },
     "watch": {
@@ -18846,9 +18849,9 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
       "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
       "requires": {
-        "async": "2.5.0",
-        "chokidar": "1.7.0",
-        "graceful-fs": "4.1.11"
+        "async": "^2.1.2",
+        "chokidar": "^1.7.0",
+        "graceful-fs": "^4.1.2"
       }
     },
     "wbuf": {
@@ -18856,11 +18859,12 @@
       "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
       "integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
       "requires": {
-        "minimalistic-assert": "1.0.0"
+        "minimalistic-assert": "^1.0.0"
       }
     },
     "webcrypto-shim": {
-      "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+      "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+      "from": "webcrypto-shim@github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
     },
     "webidl-conversions": {
       "version": "4.0.2",
@@ -18872,28 +18876,28 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.5.1.tgz",
       "integrity": "sha1-t0nuPStaEY2tU+jkFYWz9x51SZo=",
       "requires": {
-        "acorn": "5.1.2",
-        "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.2.3",
-        "ajv-keywords": "2.1.0",
-        "async": "2.5.0",
-        "enhanced-resolve": "3.4.1",
-        "escope": "3.6.0",
-        "interpret": "1.0.4",
-        "json-loader": "0.5.7",
-        "json5": "0.5.1",
-        "loader-runner": "2.3.0",
-        "loader-utils": "1.1.0",
-        "memory-fs": "0.4.1",
-        "mkdirp": "0.5.1",
-        "node-libs-browser": "2.0.0",
-        "source-map": "0.5.7",
-        "supports-color": "4.4.0",
-        "tapable": "0.2.8",
-        "uglifyjs-webpack-plugin": "0.4.6",
-        "watchpack": "1.4.0",
-        "webpack-sources": "1.0.1",
-        "yargs": "8.0.2"
+        "acorn": "^5.0.0",
+        "acorn-dynamic-import": "^2.0.0",
+        "ajv": "^5.1.5",
+        "ajv-keywords": "^2.0.0",
+        "async": "^2.1.2",
+        "enhanced-resolve": "^3.4.0",
+        "escope": "^3.6.0",
+        "interpret": "^1.0.0",
+        "json-loader": "^0.5.4",
+        "json5": "^0.5.1",
+        "loader-runner": "^2.3.0",
+        "loader-utils": "^1.1.0",
+        "memory-fs": "~0.4.1",
+        "mkdirp": "~0.5.0",
+        "node-libs-browser": "^2.0.0",
+        "source-map": "^0.5.3",
+        "supports-color": "^4.2.1",
+        "tapable": "^0.2.7",
+        "uglifyjs-webpack-plugin": "^0.4.6",
+        "watchpack": "^1.4.0",
+        "webpack-sources": "^1.0.1",
+        "yargs": "^8.0.2"
       },
       "dependencies": {
         "camelcase": {
@@ -18906,8 +18910,8 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
             "wordwrap": "0.0.2"
           }
         },
@@ -18916,9 +18920,9 @@
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           },
           "dependencies": {
             "yargs": {
@@ -18926,9 +18930,9 @@
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
                 "window-size": "0.1.0"
               }
             }
@@ -18939,9 +18943,9 @@
           "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
           "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
           "requires": {
-            "source-map": "0.5.7",
-            "uglify-js": "2.8.29",
-            "webpack-sources": "1.0.1"
+            "source-map": "^0.5.6",
+            "uglify-js": "^2.8.29",
+            "webpack-sources": "^1.0.1"
           }
         },
         "wordwrap": {
@@ -18956,11 +18960,11 @@
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.0.tgz",
       "integrity": "sha1-007++y7dp+HTtdvgcolRMhllFwk=",
       "requires": {
-        "memory-fs": "0.4.1",
-        "mime": "1.3.6",
-        "path-is-absolute": "1.0.1",
-        "range-parser": "1.2.0",
-        "time-stamp": "2.0.0"
+        "memory-fs": "~0.4.1",
+        "mime": "^1.3.4",
+        "path-is-absolute": "^1.0.0",
+        "range-parser": "^1.0.3",
+        "time-stamp": "^2.0.0"
       }
     },
     "webpack-dev-server": {
@@ -18969,28 +18973,28 @@
       "integrity": "sha1-IVgPWgjNBlxxFEz29hw0W8pZqLg=",
       "requires": {
         "ansi-html": "0.0.7",
-        "bonjour": "3.5.0",
-        "chokidar": "1.7.0",
-        "compression": "1.7.1",
-        "connect-history-api-fallback": "1.3.0",
-        "del": "3.0.0",
-        "express": "4.16.1",
-        "html-entities": "1.2.1",
-        "http-proxy-middleware": "0.17.4",
-        "internal-ip": "1.2.0",
-        "ip": "1.1.5",
-        "loglevel": "1.5.0",
+        "bonjour": "^3.5.0",
+        "chokidar": "^1.6.0",
+        "compression": "^1.5.2",
+        "connect-history-api-fallback": "^1.3.0",
+        "del": "^3.0.0",
+        "express": "^4.13.3",
+        "html-entities": "^1.2.0",
+        "http-proxy-middleware": "~0.17.4",
+        "internal-ip": "^1.2.0",
+        "ip": "^1.1.5",
+        "loglevel": "^1.4.1",
         "opn": "4.0.2",
-        "portfinder": "1.0.13",
-        "selfsigned": "1.10.1",
-        "serve-index": "1.9.1",
+        "portfinder": "^1.0.9",
+        "selfsigned": "^1.9.1",
+        "serve-index": "^1.7.2",
         "sockjs": "0.3.18",
         "sockjs-client": "1.1.4",
-        "spdy": "3.4.7",
-        "strip-ansi": "3.0.1",
-        "supports-color": "3.2.3",
-        "webpack-dev-middleware": "1.12.0",
-        "yargs": "6.6.0"
+        "spdy": "^3.4.1",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^3.1.1",
+        "webpack-dev-middleware": "^1.11.0",
+        "yargs": "^6.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -19003,12 +19007,12 @@
           "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
           "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
           "requires": {
-            "globby": "6.1.0",
-            "is-path-cwd": "1.0.0",
-            "is-path-in-cwd": "1.0.0",
-            "p-map": "1.2.0",
-            "pify": "3.0.0",
-            "rimraf": "2.2.8"
+            "globby": "^6.1.0",
+            "is-path-cwd": "^1.0.0",
+            "is-path-in-cwd": "^1.0.0",
+            "p-map": "^1.1.1",
+            "pify": "^3.0.0",
+            "rimraf": "^2.2.8"
           }
         },
         "find-up": {
@@ -19016,8 +19020,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "globby": {
@@ -19025,11 +19029,11 @@
           "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           },
           "dependencies": {
             "pify": {
@@ -19049,11 +19053,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           },
           "dependencies": {
             "pify": {
@@ -19068,8 +19072,8 @@
           "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
           "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
           "requires": {
-            "object-assign": "4.1.1",
-            "pinkie-promise": "2.0.1"
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "os-locale": {
@@ -19077,7 +19081,7 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
-            "lcid": "1.0.0"
+            "lcid": "^1.0.0"
           }
         },
         "path-exists": {
@@ -19085,7 +19089,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-type": {
@@ -19093,9 +19097,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           },
           "dependencies": {
             "pify": {
@@ -19110,9 +19114,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -19120,8 +19124,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "strip-bom": {
@@ -19129,7 +19133,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "supports-color": {
@@ -19137,7 +19141,7 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         },
         "which-module": {
@@ -19150,19 +19154,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "4.2.1"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^4.2.0"
           }
         },
         "yargs-parser": {
@@ -19170,7 +19174,7 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
           "requires": {
-            "camelcase": "3.0.0"
+            "camelcase": "^3.0.0"
           }
         }
       }
@@ -19180,8 +19184,8 @@
       "resolved": "https://registry.npmjs.org/webpack-manifest-plugin/-/webpack-manifest-plugin-1.2.1.tgz",
       "integrity": "sha512-9oLMhGlez5JSRv0dWCoxGHHdrYWrDJa8gIHeMFVuY8Fp4noQebXyFlE3fFE/BCYC4C1rG3RyEBPz0aWq1dtYDw==",
       "requires": {
-        "fs-extra": "0.30.0",
-        "lodash": "4.17.4"
+        "fs-extra": "^0.30.0",
+        "lodash": ">=3.5 <5"
       },
       "dependencies": {
         "fs-extra": {
@@ -19189,11 +19193,11 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.2.8"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
           }
         },
         "jsonfile": {
@@ -19201,7 +19205,7 @@
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.6"
           }
         }
       }
@@ -19211,8 +19215,8 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
       "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
       "requires": {
-        "source-list-map": "2.0.0",
-        "source-map": "0.5.7"
+        "source-list-map": "^2.0.0",
+        "source-map": "~0.5.3"
       },
       "dependencies": {
         "source-list-map": {
@@ -19223,15 +19227,16 @@
       }
     },
     "webrtcsupport": {
-      "version": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615"
+      "version": "github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615",
+      "from": "webrtcsupport@github:ipfs/webrtcsupport#0669f576582c53a3a42aa5ac014fcc5966809615"
     },
     "websocket-driver": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "requires": {
-        "http-parser-js": "0.4.8",
-        "websocket-extensions": "0.1.2"
+        "http-parser-js": ">=0.4.0",
+        "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {
@@ -19264,8 +19269,8 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
       "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
       "requires": {
-        "tr46": "0.0.3",
-        "webidl-conversions": "3.0.1"
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       },
       "dependencies": {
         "webidl-conversions": {
@@ -19285,7 +19290,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -19303,7 +19308,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2"
       }
     },
     "widest-line": {
@@ -19311,7 +19316,7 @@
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
       "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.1"
       }
     },
     "wif": {
@@ -19319,7 +19324,7 @@
       "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
       "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
       "requires": {
-        "bs58check": "2.1.1"
+        "bs58check": "<3.0.0"
       }
     },
     "window-size": {
@@ -19337,8 +19342,8 @@
       "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.0.tgz",
       "integrity": "sha512-DHRiUggxtbruaTwnLDm2/BRDKZIoOYvrgYUj5Bam4fU6Gtvc0FaEyoswFPBjMXAweGW2H4BDNIpy//1yXXuaqQ==",
       "requires": {
-        "errno": "0.1.4",
-        "xtend": "4.0.1"
+        "errno": "^0.1.4",
+        "xtend": "^4.0.1"
       }
     },
     "wrap-ansi": {
@@ -19346,8 +19351,8 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrappy": {
@@ -19360,8 +19365,8 @@
       "resolved": "https://registry.npmjs.org/wreck/-/wreck-12.5.1.tgz",
       "integrity": "sha512-l5DUGrc+yDyIflpty1x9XuMj1ehVjC/dTbF3/BasOO77xk0EdEa4M/DuOY8W88MQDAD0fEDqyjc8bkIMHd2E9A==",
       "requires": {
-        "boom": "5.2.0",
-        "hoek": "4.2.0"
+        "boom": "5.x.x",
+        "hoek": "4.x.x"
       }
     },
     "write": {
@@ -19369,7 +19374,7 @@
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "write-file-atomic": {
@@ -19377,9 +19382,9 @@
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "ws": {
@@ -19387,9 +19392,9 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "ultron": "1.1.1"
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
       }
     },
     "x-is-function": {
@@ -19447,10 +19452,10 @@
       "resolved": "https://registry.npmjs.org/y-ipfs-connector/-/y-ipfs-connector-2.2.0.tgz",
       "integrity": "sha512-FytiEIqOAQKsSozGBEeunY1xitiyRfzo0th5vj31QKU5by2PibNcw4QFg2uHicz7tH8nlfc3MdqnpK4vsX3vWQ==",
       "requires": {
-        "async": "2.5.0",
-        "debug": "3.1.0",
-        "ipfs-pubsub-room": "1.2.0",
-        "safe-buffer": "5.1.1"
+        "async": "^2.4.1",
+        "debug": "^3.1.0",
+        "ipfs-pubsub-room": "^1.2.0",
+        "safe-buffer": "^5.1.1"
       }
     },
     "y-map": {
@@ -19473,7 +19478,7 @@
       "resolved": "https://registry.npmjs.org/y-text/-/y-text-9.5.1.tgz",
       "integrity": "sha512-uwNLY4LeLLR7Cu4xfvh9ZY4gmOYyjii4irDHYRuhPDs1XFcm6krVaALeggA42LevTQ+k5q1eHpdv5jnJha8r6g==",
       "requires": {
-        "fast-diff": "1.1.2"
+        "fast-diff": "^1.1.1"
       }
     },
     "y18n": {
@@ -19491,19 +19496,19 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
       "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
       "requires": {
-        "camelcase": "4.1.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "read-pkg-up": "2.0.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "7.0.0"
+        "camelcase": "^4.1.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "read-pkg-up": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^7.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -19521,8 +19526,8 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -19530,7 +19535,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -19540,7 +19545,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       }
     },
     "yeast": {
@@ -19553,7 +19558,7 @@
       "resolved": "https://registry.npmjs.org/yjs/-/yjs-12.3.3.tgz",
       "integrity": "sha1-e+wU1Zr+Fm1ozCsnQTGTwOW6ckw=",
       "requires": {
-        "debug": "2.6.9"
+        "debug": "^2.6.3"
       },
       "dependencies": {
         "debug": {
@@ -19571,12 +19576,12 @@
       "resolved": "https://registry.npmjs.org/zcash-bitcore-lib/-/zcash-bitcore-lib-0.13.20-rc3.tgz",
       "integrity": "sha1-gToPVtz4t2vBQplRvqbRI2xQcAg=",
       "requires": {
-        "bn.js": "2.0.4",
-        "bs58": "2.0.0",
-        "buffer-compare": "1.0.0",
-        "elliptic": "3.0.3",
-        "inherits": "2.0.1",
-        "lodash": "3.10.1"
+        "bn.js": "=2.0.4",
+        "bs58": "=2.0.0",
+        "buffer-compare": "=1.0.0",
+        "elliptic": "=3.0.3",
+        "inherits": "=2.0.1",
+        "lodash": "=3.10.1"
       },
       "dependencies": {
         "bn.js": {
@@ -19599,10 +19604,10 @@
           "resolved": "http://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
           "integrity": "sha1-hlybQgv75VAGuflp+XoNLESWZZU=",
           "requires": {
-            "bn.js": "2.0.4",
-            "brorand": "1.0.5",
-            "hash.js": "1.0.3",
-            "inherits": "2.0.1"
+            "bn.js": "^2.0.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "inherits": "^2.0.1"
           },
           "dependencies": {
             "brorand": {
@@ -19615,7 +19620,7 @@
               "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
               "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
               "requires": {
-                "inherits": "2.0.1"
+                "inherits": "^2.0.1"
               }
             }
           }


### PR DESCRIPTION
Updates Makefile to use npm@6 and the `npm ci` command, and updates the package-lock.json.

Local testing showed that the `yarn` install and build left the production bundle firing off errors, while the `npm` build doesn't. I don't know why. Details are in #150 

Adds documentation on how the deploy happens for future code spelunkers.

Fix #150