### PR TITLE
(fix): Catch 404s in e2e test

### DIFF
--- a/test/e2e/smoke.test.js
+++ b/test/e2e/smoke.test.js
@@ -29,56 +29,66 @@ afterEach(() => {
 })
 
 it('creates a pad', async () => {
-  const user = await createTabForUser('user')
+  const page = await createPage()
 
   // Catch any errors
   const errors = []
-  user.on('error', err => errors.push(err.message)) // Emitted when the page crashes.
-  user.on('pageerror', err => errors.push(err.message)) // Emitted when an uncaught exception happens within the page.
-  user.on('requestfailed', req => {
+  page.on('error', err => errors.push(err.message)) // Emitted when the page crashes.
+  page.on('pageerror', err => errors.push(err.message)) // Emitted when an uncaught exception happens within the page.
+  page.on('requestfailed', req => {
     errors.push(`${req.failure().errorText} ${req.url()}`)
   })
-  user.on('response', res => {
+  page.on('response', res => {
     if (res.status() >= 400) {
       errors.push(`${res.status()} ${res.url()}`)
     }
   })
 
   // Create a pad and wait for IPFS to init.
-  await createNewPad(user)
-  const peerId = await findPeerId(user)
+  await createNewPad(page)
+  const peerId = await waitForPeerId(page)
   console.log('peerId', peerId)
+
   expect(peerId).toBeTruthy()
   expect(peerId.length).toBeGreaterThan(10)
-
   errors.forEach(err => console.log(err))
   expect(errors.length).toBe(0)
 }, ms.minutes(3))
 
 it('synchronises two pads via IPFS', async () => {
   const docTitleSelector = '[data-id=document-title-input]'
-  const alf = await createTabForUser('alf')
+
+  const alf = await createPage()
   await createNewPad(alf)
-  const alfPeerId = await findPeerId(alf)
+  const alfPeerId = await waitForPeerId(alf)
+  console.log('alf peerId', alfPeerId)
   expect(alfPeerId).toBeTruthy()
   const alfTitle = 'I R ROBOT'
   await alf.type(docTitleSelector, alfTitle)
+  const padUrl = alf.url()
+  console.log('pad url', padUrl)
 
-  const bob = await createTabForUser('bob')
-  console.log('pad url', alf.url())
-  await bob.goto(alf.url())
-  const bobPeerId = await findPeerId(bob)
+  const bob = await createPage()
+  await bob.goto(padUrl)
+  const bobPeerId = await waitForPeerId(bob)
   expect(bobPeerId).toBeTruthy()
   expect(bobPeerId).not.toEqual(alfPeerId)
-  console.log('alf peerId', alfPeerId)
   console.log('bob peerId', bobPeerId)
 
   // Wait for bob's doc title to match alf's
   const bobTitleRef = await bob.$(docTitleSelector)
   const valueMatches = (input, expected) => input.value === expected
-  // waitFor fn is executed in the browser context, so args have to passed in.
+  // waitFor fn is executed in the browser context, so context has to passed as args.
   await bob.waitFor(valueMatches, {/* opts */}, bobTitleRef, alfTitle)
 }, ms.minutes(6)) // spinning up 2 browsers and syncing pads can take a while.
+
+async function createPage () {
+  const browser = await createBrowser()
+  const page = await browser.newPage()
+  // See: https://github.com/GoogleChrome/puppeteer/issues/1183#issuecomment-383722137
+  await page._client.send('Emulation.clearDeviceMetricsOverride')
+  return page
+}
 
 async function createNewPad (page) {
   await page.goto(appUrl)
@@ -88,19 +98,10 @@ async function createNewPad (page) {
   await page.waitForSelector('[data-id=ipfs-status][data-value=online]', {timeout: ms.minutes(2)})
 }
 
-async function findPeerId (page) {
+async function waitForPeerId (page) {
   // wait for IPFS to boot
   await page.waitForSelector('[data-peer-id]', {timeout: ms.minutes(2)})
   const peersButton = await page.$('[data-peer-id]')
   const peerId = await page.evaluate(el => el.dataset.peerId, peersButton)
   return peerId
-}
-
-async function createTabForUser (username) {
-  const browser = await createBrowser()
-  const page = await browser.newPage()
-  // See: https://github.com/GoogleChrome/puppeteer/issues/1183#issuecomment-383722137
-  await page._client.send('Emulation.clearDeviceMetricsOverride')
-  // page.on('console', msg => console.log(`${username} console:`, msg.text()))
-  return page
 }


### PR DESCRIPTION
- Test error if any request results in a >=400 status code.
- Use waitFor to wait for the doc titles to match rather than waiting for 5s