### PR TITLE
chore: fix undefined values in jest snapshots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3616,9 +3616,9 @@
       }
     },
     "enzyme-to-json": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.1.2.tgz",
-      "integrity": "sha512-L75cYAmiaeb3lleLg9bc0iDtDgMRPsdyJkh69SquE+JS2cw7rURN77VXV2sue9AOzQ3HszWvr7AJyWV3PYZdtA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.3.3.tgz",
+      "integrity": "sha1-7eRZOPswnNh+vUOG9gx1RSVRWgc=",
       "dev": true,
       "requires": {
         "lodash": "^4.17.4"
@@ -17390,7 +17390,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "devDependencies": {
     "enzyme": "^3.0.0",
     "enzyme-adapter-react-15": "^1.0.1",
-    "enzyme-to-json": "^3.1.2",
+    "enzyme-to-json": "^3.3.3",
     "http-server": "^0.11.1",
     "npm-run-all": "^4.1.2",
     "pre-commit": "^1.2.2",

--- a/src/components/home/__snapshots__/Home.test.js.snap
+++ b/src/components/home/__snapshots__/Home.test.js.snap
@@ -25,7 +25,6 @@ exports[`can create document via button 1`] = `
           <svg
             className="dib fill--current-color v-mid mr3"
             height="26"
-            style={undefined}
             viewBox="0 0 149 146.7"
             width="26"
             xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Older versions of enzyme-to-json would output explicitly undefined
prop values as `style={undefined}`. Since v3.2.1 it has ommitted
undefind prop values. Our package.json allowed for people to use
either version, and we only just got a package-lock file so PRs
kept failing as we're all using different versions and having to
push changes to snapshots that either fail locally or in ci.

This PR pins enzyme-to-json to the latest for all of us. No more
undefined property values in snapshots. Now we just need to write
some good tests.

Fixes #163

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>