### PR TITLE
feat: add css modules

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -22,6 +22,52 @@ const publicUrl = '';
 // Get environment variables to inject into our app.
 const env = getClientEnvironment(publicUrl);
 
+// "postcss" loader applies autoprefixer to our CSS.
+// "css" loader resolves paths in CSS and adds assets as dependencies.
+// "style" loader turns CSS into JS modules that inject <style> tags.
+// In production, we use a plugin to extract that CSS to a file, but
+// in development "style" loader enables hot editing of CSS.
+// This is moved out of rules so that the configuration can be shared across
+// global and module css files.
+const createCssRule = ({ modules = false } = {}) => ({
+  test: /\.css$/,
+  [modules ? 'include' : 'exclude']: (filename) => filename.endsWith('.module.css'),
+  use: [
+    require.resolve('style-loader'),
+    {
+      loader: require.resolve('css-loader'),
+      options: Object.assign({
+        importLoaders: 1,
+      }, modules && {
+        modules: true,
+        localIdentName: '[path][name]__[local]--[hash:base64:5]',
+      }),
+    },
+    {
+      loader: require.resolve('postcss-loader'),
+      options: {
+        // Necessary for external CSS imports to work
+        // https://github.com/facebookincubator/create-react-app/issues/2677
+        ident: 'postcss',
+        plugins: () => [
+          require('postcss-import'),
+          require('postcss-css-variables'),
+          require('postcss-flexbugs-fixes'),
+          autoprefixer({
+            browsers: [
+              '>1%',
+              'last 4 versions',
+              'Firefox ESR',
+              'not ie < 9', // React doesn't support IE8 anyway
+            ],
+            flexbox: 'no-2009',
+          }),
+        ],
+      },
+    },
+  ],
+})
+
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.
 // The production configuration is different and lives in a separate file.
@@ -156,45 +202,8 @@ module.exports = {
               cacheDirectory: true,
             },
           },
-          // "postcss" loader applies autoprefixer to our CSS.
-          // "css" loader resolves paths in CSS and adds assets as dependencies.
-          // "style" loader turns CSS into JS modules that inject <style> tags.
-          // In production, we use a plugin to extract that CSS to a file, but
-          // in development "style" loader enables hot editing of CSS.
-          {
-            test: /\.css$/,
-            use: [
-              require.resolve('style-loader'),
-              {
-                loader: require.resolve('css-loader'),
-                options: {
-                  importLoaders: 1,
-                },
-              },
-              {
-                loader: require.resolve('postcss-loader'),
-                options: {
-                  // Necessary for external CSS imports to work
-                  // https://github.com/facebookincubator/create-react-app/issues/2677
-                  ident: 'postcss',
-                  plugins: () => [
-                    require('postcss-import'),
-                    require('postcss-css-variables'),
-                    require('postcss-flexbugs-fixes'),
-                    autoprefixer({
-                      browsers: [
-                        '>1%',
-                        'last 4 versions',
-                        'Firefox ESR',
-                        'not ie < 9', // React doesn't support IE8 anyway
-                      ],
-                      flexbox: 'no-2009',
-                    }),
-                  ],
-                },
-              },
-            ],
-          },
+          createCssRule(),
+          createCssRule({ modules: true }),
           // "file" loader makes sure those assets get served by WebpackDevServer.
           // When you `import` an asset, you get its (virtual) filename.
           // In production, they would get copied to the `build` folder.

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -47,6 +47,67 @@ const extractTextPluginOptions = shouldUseRelativeAssetPaths
     { publicPath: Array(cssFilename.split('/').length).join('../') }
   : {};
 
+// The notation here is somewhat confusing.
+// "postcss" loader applies autoprefixer to our CSS.
+// "css" loader resolves paths in CSS and adds assets as dependencies.
+// "style" loader normally turns CSS into JS modules injecting <style>,
+// but unlike in development configuration, we do something different.
+// `ExtractTextPlugin` first applies the "postcss" and "css" loaders
+// (second argument), then grabs the result CSS and puts it into a
+// separate file in our build process. This way we actually ship
+// a single CSS file in production instead of JS code injecting <style>
+// tags. If you use code splitting, however, any async bundles will still
+// use the "style" loader inside the async code so CSS from them won't be
+// in the main CSS file.
+const createCssRule = ({ modules = false } = {}) => ({
+  test: /\.css$/,
+  [modules ? 'include' : 'exclude']: (filename) => filename.endsWith('.module.css'),
+  loader: ExtractTextPlugin.extract(
+    Object.assign(
+      {
+        fallback: require.resolve('style-loader'),
+        use: [
+          {
+            loader: require.resolve('css-loader'),
+            options: Object.assign({
+              importLoaders: 1,
+              minimize: true,
+              sourceMap: shouldUseSourceMap,
+            }, modules && {
+              modules: true,
+              localIdentName: '[hash:base64:5]',
+            }),
+          },
+          {
+            loader: require.resolve('postcss-loader'),
+            options: {
+              // Necessary for external CSS imports to work
+              // https://github.com/facebookincubator/create-react-app/issues/2677
+              ident: 'postcss',
+              plugins: () => [
+                require('postcss-import'),
+                require('postcss-css-variables'),
+                require('postcss-flexbugs-fixes'),
+                autoprefixer({
+                  browsers: [
+                    '>1%',
+                    'last 4 versions',
+                    'Firefox ESR',
+                    'not ie < 9', // React doesn't support IE8 anyway
+                  ],
+                  flexbox: 'no-2009',
+                }),
+              ],
+            },
+          },
+        ],
+      },
+      extractTextPluginOptions
+    )
+  ),
+  // Note: this won't work without `new ExtractTextPlugin()` in `plugins`.
+})
+
 // This is the production configuration.
 // It compiles slowly and is focused on producing a fast and minimal bundle.
 // The development configuration is different and lives in a separate file.
@@ -157,62 +218,8 @@ module.exports = {
               compact: true,
             },
           },
-          // The notation here is somewhat confusing.
-          // "postcss" loader applies autoprefixer to our CSS.
-          // "css" loader resolves paths in CSS and adds assets as dependencies.
-          // "style" loader normally turns CSS into JS modules injecting <style>,
-          // but unlike in development configuration, we do something different.
-          // `ExtractTextPlugin` first applies the "postcss" and "css" loaders
-          // (second argument), then grabs the result CSS and puts it into a
-          // separate file in our build process. This way we actually ship
-          // a single CSS file in production instead of JS code injecting <style>
-          // tags. If you use code splitting, however, any async bundles will still
-          // use the "style" loader inside the async code so CSS from them won't be
-          // in the main CSS file.
-          {
-            test: /\.css$/,
-            loader: ExtractTextPlugin.extract(
-              Object.assign(
-                {
-                  fallback: require.resolve('style-loader'),
-                  use: [
-                    {
-                      loader: require.resolve('css-loader'),
-                      options: {
-                        importLoaders: 1,
-                        minimize: true,
-                        sourceMap: shouldUseSourceMap,
-                      },
-                    },
-                    {
-                      loader: require.resolve('postcss-loader'),
-                      options: {
-                        // Necessary for external CSS imports to work
-                        // https://github.com/facebookincubator/create-react-app/issues/2677
-                        ident: 'postcss',
-                        plugins: () => [
-                          require('postcss-import'),
-                          require('postcss-css-variables'),
-                          require('postcss-flexbugs-fixes'),
-                          autoprefixer({
-                            browsers: [
-                              '>1%',
-                              'last 4 versions',
-                              'Firefox ESR',
-                              'not ie < 9', // React doesn't support IE8 anyway
-                            ],
-                            flexbox: 'no-2009',
-                          }),
-                        ],
-                      },
-                    },
-                  ],
-                },
-                extractTextPluginOptions
-              )
-            ),
-            // Note: this won't work without `new ExtractTextPlugin()` in `plugins`.
-          },
+          createCssRule(),
+          createCssRule({ modules: true }),
           // "file" loader makes sure assets end up in the `build` folder.
           // When you `import` an asset, you get its filename.
           // This loader don't uses a "test" so it will catch all modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -2593,7 +2593,7 @@
     },
     "compression": {
       "version": "1.7.2",
-      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
       "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "requires": {
         "accepts": "~1.3.4",
@@ -5153,7 +5153,7 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-ext": {
-      "version": "github:baudehlo/node-fs-ext#f5c9c9ec584937f8b216335d0c36d238b5d187c9",
+      "version": "github:baudehlo/node-fs-ext#500be8514729c194ac7ca2b30b5bc7eaf812670d",
       "from": "github:baudehlo/node-fs-ext#master",
       "optional": true,
       "requires": {
@@ -11052,7 +11052,7 @@
       "requires": {
         "async": "^2.1.5",
         "find-process": "^1.0.5",
-        "fs-ext": "github:baudehlo/node-fs-ext#f5c9c9ec584937f8b216335d0c36d238b5d187c9",
+        "fs-ext": "github:baudehlo/node-fs-ext#500be8514729c194ac7ca2b30b5bc7eaf812670d",
         "nodeify": "^1.0.1",
         "once": "^1.4.0"
       }
@@ -16763,7 +16763,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -19154,7 +19154,7 @@
         },
         "elliptic": {
           "version": "3.0.3",
-          "resolved": "http://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
           "integrity": "sha1-hlybQgv75VAGuflp+XoNLESWZZU=",
           "requires": {
             "bn.js": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2394,6 +2394,11 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
+      "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
+    },
     "clean-css": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
@@ -7177,6 +7182,12 @@
         "har-schema": "^2.0.0"
       }
     },
+    "harmony-reflect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.0.tgz",
+      "integrity": "sha512-0kZ1XcoelFOLEjEtvWAZyq/1S55eDSieWEJwme311MNVNcRpvjlr2zA66kBV6WAB8C1XI1p1cXCnFPqd1BxlPg==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
@@ -7850,6 +7861,15 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/idb-wrapper/-/idb-wrapper-1.7.2.tgz",
       "integrity": "sha512-zfNREywMuf0NzDo9mVsL0yegjsirJxHpKHvWcyRozIqQy89g0a3U+oBPOCN4cc0oCiOuYgZHimzaW/R46G1Mpg=="
+    },
+    "identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
+      "dev": true,
+      "requires": {
+        "harmony-reflect": "^1.4.6"
+      }
     },
     "ieee754": {
       "version": "1.1.11",
@@ -10429,12 +10449,22 @@
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
             "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          },
+          "dependencies": {
+            "webcrypto-shim": {
+              "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+              "from": "github:dignifiedquire/webcrypto-shim#master"
+            }
           }
         },
         "tweetnacl": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -10504,12 +10534,22 @@
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
             "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          },
+          "dependencies": {
+            "webcrypto-shim": {
+              "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+              "from": "github:dignifiedquire/webcrypto-shim#master"
+            }
           }
         },
         "tweetnacl": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -10544,12 +10584,22 @@
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
             "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          },
+          "dependencies": {
+            "webcrypto-shim": {
+              "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+              "from": "github:dignifiedquire/webcrypto-shim#master"
+            }
           }
         },
         "tweetnacl": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -10618,12 +10668,22 @@
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
             "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          },
+          "dependencies": {
+            "webcrypto-shim": {
+              "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+              "from": "github:dignifiedquire/webcrypto-shim#master"
+            }
           }
         },
         "tweetnacl": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -10709,12 +10769,22 @@
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
             "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          },
+          "dependencies": {
+            "webcrypto-shim": {
+              "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+              "from": "github:dignifiedquire/webcrypto-shim#master"
+            }
           }
         },
         "tweetnacl": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -10863,12 +10933,22 @@
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
             "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          },
+          "dependencies": {
+            "webcrypto-shim": {
+              "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+              "from": "github:dignifiedquire/webcrypto-shim#master"
+            }
           }
         },
         "tweetnacl": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },
@@ -12719,12 +12799,22 @@
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
             "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+          },
+          "dependencies": {
+            "webcrypto-shim": {
+              "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+              "from": "github:dignifiedquire/webcrypto-shim#master"
+            }
           }
         },
         "tweetnacl": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bs58": "^4.0.1",
     "case-sensitive-paths-webpack-plugin": "2.1.1",
     "chalk": "1.1.3",
+    "classnames": "^2.2.5",
     "codemirror": "^5.30.0",
     "css-loader": "0.28.4",
     "dotenv": "4.0.0",
@@ -73,6 +74,7 @@
     "enzyme-adapter-react-15": "^1.0.1",
     "enzyme-to-json": "^3.3.4",
     "http-server": "^0.11.1",
+    "identity-obj-proxy": "^3.0.0",
     "npm-run-all": "^4.1.2",
     "pre-commit": "^1.2.2",
     "puppeteer": "^1.3.0",
@@ -99,11 +101,12 @@
     "testURL": "http://localhost",
     "transform": {
       "^.+\\.(js|jsx)$": "<rootDir>/node_modules/babel-jest",
-      "^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",
+      "^.+(?!\\.module\\.)\\.css$": "<rootDir>/config/jest/cssTransform.js",
       "^(?!.*\\.(js|jsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
     },
     "moduleNameMapper": {
-      "^react-native$": "react-native-web"
+      "^react-native$": "react-native-web",
+      "^.+\\.module\\.css$": "identity-obj-proxy"
     },
     "moduleFileExtensions": [
       "web.js",

--- a/src/components/home/Home.css
+++ b/src/components/home/Home.css
@@ -107,11 +107,6 @@
   header {
     padding-bottom: 0 !important;
   }
-  button[data-id="start-button"] {
-    margin: 10px;
-    background-color: #23e0f7;
-    color: rgb(4, 17, 37);
-  }
 }
 
 /* Hero cursor blinking */

--- a/src/components/home/Home.css
+++ b/src/components/home/Home.css
@@ -95,62 +95,15 @@
   border-bottom-color: transparent
 }
 
-/* Mobile-friendly top nav */
-
-.top-nav .menu-toggle {
-  visibility: hidden;
-  position: absolute;
-  left: -100%;
-}
-
-.top-nav label {
-  display: none;
-}
-
-.top-nav ul {
-  padding: 0;
-}
-
-.top-nav ul li {
-  display: inline-block;
-}
-
-.top-nav ul li a {
-  display: inline-block;
-  margin: 0;
-}
-
 @media screen and (max-width: 1160px) {
   header a[title="Home"] {
     display: inline-block;
     margin: 0 auto;
     width: auto;
   }
-  .top-nav {
-    display: block;
-    width: 100%;
-    text-align: center;
-  }
 }
 
 @media screen and (max-width: 775px) {
-  .top-nav ul {
-    display: none;
-    border-bottom: 1px solid rgba(255,255,255,.3);
-    padding-bottom: 10px;
-  }
-  .top-nav label {
-    display: inline-block;
-  }
-  .top-nav .menu-toggle:checked ~ ul,
-  .top-nav .menu-toggle:checked ~ ul > li {
-    display: block;
-  }
-  .top-nav label {
-    padding: 10px;
-    margin-bottom: 0;
-    cursor: pointer;
-  }
   header {
     padding-bottom: 0 !important;
   }

--- a/src/components/home/Home.js
+++ b/src/components/home/Home.js
@@ -29,7 +29,7 @@ class Home extends Component {
 
             <div className={cx('db dtc-l v-btm w-100 w-75-l tc tr-l', styles.topNav)}>
 
-              <input id="menu-toggle" className="menu-toggle" type="checkbox"/>
+              <input id="menu-toggle" className={styles.menuToggle} type="checkbox"/>
               <label htmlFor="menu-toggle" className='mt4 w-auto bg-transparent ba b--bright-turquoise bright-turquoise fw2 tracked--1 pointer dim' style={{fontSize: '15px', padding: '5px 28px'}}>Menu</label>
 
               <ul>

--- a/src/components/home/Home.js
+++ b/src/components/home/Home.js
@@ -1,10 +1,12 @@
 import React, { Component } from 'react'
 import { HashLink as Link } from 'react-router-hash-link'
+import cx from 'classnames'
 import CreateDocument from './CreateDocument'
 import StartButton from './StartButton'
 import Warning from '../Warning'
 import Hexicon from './Hexicon'
 import './Home.css'
+import styles from './Home.module.css'
 
 class Home extends Component {
   constructor (props) {
@@ -25,7 +27,7 @@ class Home extends Component {
               <img src='images/logo-peerpad-lg.svg' className='dib' alt='PeerPad' style={{height: '100px'}} />
             </a>
 
-            <div className='db dtc-l v-btm w-100 w-75-l tc tr-l top-nav'>
+            <div className={cx('db dtc-l v-btm w-100 w-75-l tc tr-l', styles.topNav)}>
 
               <input id="menu-toggle" className="menu-toggle" type="checkbox"/>
               <label htmlFor="menu-toggle" className='mt4 w-auto bg-transparent ba b--bright-turquoise bright-turquoise fw2 tracked--1 pointer dim' style={{fontSize: '15px', padding: '5px 28px'}}>Menu</label>

--- a/src/components/home/Home.module.css
+++ b/src/components/home/Home.module.css
@@ -1,0 +1,54 @@
+@import '../../colors.css';
+
+/* Mobile-friendly top nav */
+
+.topNav .menu-toggle {
+  visibility: hidden;
+  position: absolute;
+  left: -100%;
+}
+
+.topNav label {
+  display: none;
+}
+
+.topNav ul {
+  padding: 0;
+}
+
+.topNav ul li {
+  display: inline-block;
+}
+
+.topNav ul li a {
+  display: inline-block;
+  margin: 0;
+}
+
+@media screen and (max-width: 1160px) {
+  .topNav {
+    display: block;
+    width: 100%;
+    text-align: center;
+  }
+}
+
+@media screen and (max-width: 775px) {
+  .topNav ul {
+    display: none;
+    border-bottom: 1px solid rgba(255,255,255,.3);
+    padding-bottom: 10px;
+  }
+  .topNav label {
+    display: inline-block;
+  }
+  .topNav .menu-toggle:checked ~ ul,
+  .topNav .menu-toggle:checked ~ ul > li {
+    display: block;
+  }
+  .topNav label {
+    padding: 10px;
+    margin-bottom: 0;
+    cursor: pointer;
+  }
+}

--- a/src/components/home/Home.module.css
+++ b/src/components/home/Home.module.css
@@ -2,7 +2,7 @@
 
 /* Mobile-friendly top nav */
 
-.topNav .menu-toggle {
+.topNav .menuToggle {
   visibility: hidden;
   position: absolute;
   left: -100%;
@@ -42,13 +42,18 @@
   .topNav label {
     display: inline-block;
   }
-  .topNav .menu-toggle:checked ~ ul,
-  .topNav .menu-toggle:checked ~ ul > li {
+  .topNav .menuToggle:checked ~ ul,
+  .topNav .menuToggle:checked ~ ul > li {
     display: block;
   }
   .topNav label {
     padding: 10px;
     margin-bottom: 0;
     cursor: pointer;
+  }
+  .topNav button[data-id="start-button"] {
+    margin: 10px;
+    background-color: #23e0f7;
+    color: rgb(4, 17, 37);
   }
 }

--- a/src/components/home/__snapshots__/Home.test.js.snap
+++ b/src/components/home/__snapshots__/Home.test.js.snap
@@ -77,7 +77,7 @@ exports[`can create document via button 1`] = `
           className="db dtc-l v-btm w-100 w-75-l tc tr-l topNav"
         >
           <input
-            className="menu-toggle"
+            className="menuToggle"
             id="menu-toggle"
             type="checkbox"
           />

--- a/src/components/home/__snapshots__/Home.test.js.snap
+++ b/src/components/home/__snapshots__/Home.test.js.snap
@@ -74,7 +74,7 @@ exports[`can create document via button 1`] = `
           />
         </a>
         <div
-          className="db dtc-l v-btm w-100 w-75-l tc tr-l top-nav"
+          className="db dtc-l v-btm w-100 w-75-l tc tr-l topNav"
         >
           <input
             className="menu-toggle"


### PR DESCRIPTION
Ref #169.

This adds configuration for webpack and jest so CSS files ending in `.modules.css` are treated as CSS modules. This allows for CSS files to be optionally refactored over time to convert them from global to local, while also keeping the ability for global CSS files to exist where that makes sense.

It also includes one refactor of the top nav on the homepage to a CSS module as an example of how it works.

One question I wanted to pose is whether it now makes sense to convert all the CSS files (except `colors.css` and `index.css`) to CSS modules, or to do it as time permits going forward.

