### PR TITLE
Add stylus as a webpack loader for .styl files

### DIFF
--- a/config/createStyleRule.js
+++ b/config/createStyleRule.js
@@ -1,0 +1,67 @@
+const autoprefixer = require('autoprefixer');
+
+// "postcss" loader applies autoprefixer to our CSS.
+// "css" loader resolves paths in CSS and adds assets as dependencies.
+// "style" loader turns CSS into JS modules that inject <style> tags
+// in development, but in production, we do something different.
+// In production, we use a plugin to extract that CSS to a file, but
+// in development "style" loader enables hot editing of CSS.
+// This is moved out of rules so that the configuration can be shared across
+// global/module css files and dev/prod configurations.
+module.exports = ({ modules, test, env, shouldUseSourceMap }) => {
+  const PROD = env.raw.NODE_ENV === 'production'
+
+  const otherLoaders = [
+    test.source.endsWith('\.styl$') && {
+      loader: require.resolve('stylus-loader'),
+      options: {
+        plugins: []
+      }
+    },
+    {
+      loader: require.resolve('postcss-loader'),
+      options: {
+        // Necessary for external CSS imports to work
+        // https://github.com/facebookincubator/create-react-app/issues/2677
+        ident: 'postcss',
+        plugins: () => [
+          require('postcss-import'),
+          require('postcss-css-variables'),
+          require('postcss-flexbugs-fixes'),
+          autoprefixer({
+            browsers: [
+              '>1%',
+              'last 4 versions',
+              'Firefox ESR',
+              'not ie < 9', // React doesn't support IE8 anyway
+            ],
+            flexbox: 'no-2009',
+          }),
+        ],
+      },
+    }
+  ].filter(Boolean)
+
+  return {
+    test,
+    [modules ? 'include' : 'exclude']: (filename) =>
+      new RegExp('\\.module' + test.source).test(filename),
+    use: [
+      require.resolve('style-loader'),
+      {
+        loader: require.resolve('css-loader'),
+        options: Object.assign({
+          importLoaders: otherLoaders.length,
+          minimize: PROD,
+          sourceMap: PROD && shouldUseSourceMap
+        }, modules && {
+          modules: true,
+          localIdentName: PROD
+            ? '[hash:base64:5]'
+            : '[path][name]__[local]--[hash:base64:5]',
+        }),
+      },
+      ...otherLoaders,
+    ],
+  }
+}

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const autoprefixer = require('autoprefixer');
 const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -11,6 +10,7 @@ const eslintFormatter = require('react-dev-utils/eslintFormatter');
 const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
 const getClientEnvironment = require('./env');
 const paths = require('./paths');
+const createStyleRule = require('./createStyleRule');
 
 // Webpack uses `publicPath` to determine where the app is being served from.
 // In development, we always serve from the root. This makes config easier.
@@ -21,52 +21,6 @@ const publicPath = '/';
 const publicUrl = '';
 // Get environment variables to inject into our app.
 const env = getClientEnvironment(publicUrl);
-
-// "postcss" loader applies autoprefixer to our CSS.
-// "css" loader resolves paths in CSS and adds assets as dependencies.
-// "style" loader turns CSS into JS modules that inject <style> tags.
-// In production, we use a plugin to extract that CSS to a file, but
-// in development "style" loader enables hot editing of CSS.
-// This is moved out of rules so that the configuration can be shared across
-// global and module css files.
-const createCssRule = ({ modules = false } = {}) => ({
-  test: /\.css$/,
-  [modules ? 'include' : 'exclude']: (filename) => filename.endsWith('.module.css'),
-  use: [
-    require.resolve('style-loader'),
-    {
-      loader: require.resolve('css-loader'),
-      options: Object.assign({
-        importLoaders: 1,
-      }, modules && {
-        modules: true,
-        localIdentName: '[path][name]__[local]--[hash:base64:5]',
-      }),
-    },
-    {
-      loader: require.resolve('postcss-loader'),
-      options: {
-        // Necessary for external CSS imports to work
-        // https://github.com/facebookincubator/create-react-app/issues/2677
-        ident: 'postcss',
-        plugins: () => [
-          require('postcss-import'),
-          require('postcss-css-variables'),
-          require('postcss-flexbugs-fixes'),
-          autoprefixer({
-            browsers: [
-              '>1%',
-              'last 4 versions',
-              'Firefox ESR',
-              'not ie < 9', // React doesn't support IE8 anyway
-            ],
-            flexbox: 'no-2009',
-          }),
-        ],
-      },
-    },
-  ],
-})
 
 // This is the development configuration.
 // It is focused on developer experience and fast rebuilds.
@@ -202,8 +156,10 @@ module.exports = {
               cacheDirectory: true,
             },
           },
-          createCssRule(),
-          createCssRule({ modules: true }),
+          createStyleRule({ test: /\.css$/ }),
+          createStyleRule({ modules: true, test: /\.css$/ }),
+          createStyleRule({ test: /\.styl$/ }),
+          createStyleRule({ modules: true, test: /\.styl$/ }),
           // "file" loader makes sure those assets get served by WebpackDevServer.
           // When you `import` an asset, you get its (virtual) filename.
           // In production, they would get copied to the `build` folder.

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -156,10 +156,10 @@ module.exports = {
               cacheDirectory: true,
             },
           },
-          createStyleRule({ test: /\.css$/ }),
-          createStyleRule({ modules: true, test: /\.css$/ }),
-          createStyleRule({ test: /\.styl$/ }),
-          createStyleRule({ modules: true, test: /\.styl$/ }),
+          createStyleRule({ env, test: /\.css$/ }),
+          createStyleRule({ env, modules: true, test: /\.css$/ }),
+          createStyleRule({ env, test: /\.styl$/ }),
+          createStyleRule({ env, modules: true, test: /\.styl$/ }),
           // "file" loader makes sure those assets get served by WebpackDevServer.
           // When you `import` an asset, you get its (virtual) filename.
           // In production, they would get copied to the `build` folder.

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const autoprefixer = require('autoprefixer');
 const path = require('path');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -13,6 +12,7 @@ const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 const paths = require('./paths');
 const getClientEnvironment = require('./env');
+const baseCreateStyleRule = require('./createStyleRule');
 
 // Webpack uses `publicPath` to determine where the app is being served from.
 // It requires a trailing slash, or the file assets will get an incorrect path.
@@ -47,66 +47,18 @@ const extractTextPluginOptions = shouldUseRelativeAssetPaths
     { publicPath: Array(cssFilename.split('/').length).join('../') }
   : {};
 
-// The notation here is somewhat confusing.
-// "postcss" loader applies autoprefixer to our CSS.
-// "css" loader resolves paths in CSS and adds assets as dependencies.
-// "style" loader normally turns CSS into JS modules injecting <style>,
-// but unlike in development configuration, we do something different.
-// `ExtractTextPlugin` first applies the "postcss" and "css" loaders
-// (second argument), then grabs the result CSS and puts it into a
-// separate file in our build process. This way we actually ship
-// a single CSS file in production instead of JS code injecting <style>
-// tags. If you use code splitting, however, any async bundles will still
-// use the "style" loader inside the async code so CSS from them won't be
-// in the main CSS file.
-const createCssRule = ({ modules = false } = {}) => ({
-  test: /\.css$/,
-  [modules ? 'include' : 'exclude']: (filename) => filename.endsWith('.module.css'),
-  loader: ExtractTextPlugin.extract(
-    Object.assign(
-      {
-        fallback: require.resolve('style-loader'),
-        use: [
-          {
-            loader: require.resolve('css-loader'),
-            options: Object.assign({
-              importLoaders: 1,
-              minimize: true,
-              sourceMap: shouldUseSourceMap,
-            }, modules && {
-              modules: true,
-              localIdentName: '[hash:base64:5]',
-            }),
-          },
-          {
-            loader: require.resolve('postcss-loader'),
-            options: {
-              // Necessary for external CSS imports to work
-              // https://github.com/facebookincubator/create-react-app/issues/2677
-              ident: 'postcss',
-              plugins: () => [
-                require('postcss-import'),
-                require('postcss-css-variables'),
-                require('postcss-flexbugs-fixes'),
-                autoprefixer({
-                  browsers: [
-                    '>1%',
-                    'last 4 versions',
-                    'Firefox ESR',
-                    'not ie < 9', // React doesn't support IE8 anyway
-                  ],
-                  flexbox: 'no-2009',
-                }),
-              ],
-            },
-          },
-        ],
-      },
-      extractTextPluginOptions
-    )
-  ),
+const createStyleRule = ({ modules, test }) => {
+  const styleRule = baseCreateStyleRule({ modules, test, shouldUseSourceMap, env })
+
   // Note: this won't work without `new ExtractTextPlugin()` in `plugins`.
-})
+  const [fallback, ...use] = styleRule.use
+  styleRule.loader = ExtractTextPlugin.extract(
+    Object.assign({ fallback, use }, extractTextPluginOptions)
+  )
+  delete styleRule.use
+
+  return styleRule
+}
 
 // This is the production configuration.
 // It compiles slowly and is focused on producing a fast and minimal bundle.
@@ -218,8 +170,10 @@ module.exports = {
               compact: true,
             },
           },
-          createCssRule(),
-          createCssRule({ modules: true }),
+          createStyleRule({ test: /\.css$/ }),
+          createStyleRule({ test: /\.css$/, modules: true }),
+          createStyleRule({ test: /\.styl$/ }),
+          createStyleRule({ test: /\.styl$/, modules: true }),
           // "file" loader makes sure assets end up in the `build` folder.
           // When you `import` an asset, you get its filename.
           // This loader don't uses a "test" so it will catch all modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -2593,7 +2593,7 @@
     },
     "compression": {
       "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
+      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.2.tgz",
       "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
       "requires": {
         "accepts": "~1.3.4",
@@ -2941,6 +2941,11 @@
           }
         }
       }
+    },
+    "css-parse": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz",
+      "integrity": "sha1-Mh9s9zeCpv91ERE5D8BeLGV9jJs="
     },
     "css-select": {
       "version": "1.2.0",
@@ -5153,7 +5158,7 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-ext": {
-      "version": "github:baudehlo/node-fs-ext#500be8514729c194ac7ca2b30b5bc7eaf812670d",
+      "version": "github:baudehlo/node-fs-ext#f5c9c9ec584937f8b216335d0c36d238b5d187c9",
       "from": "github:baudehlo/node-fs-ext#master",
       "optional": true,
       "requires": {
@@ -11052,7 +11057,7 @@
       "requires": {
         "async": "^2.1.5",
         "find-process": "^1.0.5",
-        "fs-ext": "github:baudehlo/node-fs-ext#500be8514729c194ac7ca2b30b5bc7eaf812670d",
+        "fs-ext": "github:baudehlo/node-fs-ext#f5c9c9ec584937f8b216335d0c36d238b5d187c9",
         "nodeify": "^1.0.1",
         "once": "^1.4.0"
       }
@@ -16763,7 +16768,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -17149,6 +17154,57 @@
       "requires": {
         "loader-utils": "^1.0.2",
         "schema-utils": "^0.3.0"
+      }
+    },
+    "stylus": {
+      "version": "0.54.5",
+      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.5.tgz",
+      "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
+      "requires": {
+        "css-parse": "1.7.x",
+        "debug": "*",
+        "glob": "7.0.x",
+        "mkdirp": "0.5.x",
+        "sax": "0.5.x",
+        "source-map": "0.1.x"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+          "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "sax": {
+          "version": "0.5.8",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+          "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
+    },
+    "stylus-loader": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/stylus-loader/-/stylus-loader-3.0.2.tgz",
+      "integrity": "sha512-+VomPdZ6a0razP+zinir61yZgpw2NfljeSsdUF5kJuEzlo3khXhY19Fn6l8QQz1GRJGtMCo8nG5C04ePyV7SUA==",
+      "requires": {
+        "loader-utils": "^1.0.2",
+        "lodash.clonedeep": "^4.5.0",
+        "when": "~3.6.x"
       }
     },
     "subtext": {
@@ -18767,6 +18823,11 @@
         }
       }
     },
+    "when": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/when/-/when-3.6.4.tgz",
+      "integrity": "sha1-RztRfsFZ4rhQBUl6E5g/CVQS404="
+    },
     "whet.extend": {
       "version": "0.9.9",
       "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
@@ -19154,7 +19215,7 @@
         },
         "elliptic": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
+          "resolved": "http://registry.npmjs.org/elliptic/-/elliptic-3.0.3.tgz",
           "integrity": "sha1-hlybQgv75VAGuflp+XoNLESWZZU=",
           "requires": {
             "bn.js": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "react-router-dom": "^4.2.2",
     "react-router-hash-link": "^1.1.1",
     "style-loader": "0.18.2",
+    "stylus": "^0.54.5",
+    "stylus-loader": "^3.0.2",
     "sw-precache-webpack-plugin": "0.11.4",
     "tachyons": "^4.8.1",
     "tachyons-flexbox": "^2.0.5",


### PR DESCRIPTION
This also refactors the style loader implementations into a single config file
that is used for both css and stylus files and across the dev and prod webpack
configurations.

Note that this doesn't add any stylus files. Those will most likely get added as necessary when refactoring as part of #169.

Closes #168