### PR TITLE
feat: add a staging server, #152

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,5 +1,8 @@
 website([
   website: 'peerpad.net',
-  record: '_dnslink',
-  build_directory: 'build/'
+  build_directory: 'build/',
+  record: [
+    'production': '_dnslink',
+    'master': '_dnslink.dev',
+  ]
 ])


### PR DESCRIPTION
This should give us access to a staging and production environment so we can better control what's in production, giving us more flexibility with development and quality assurance.

Per, https://github.com/ipfs-shipyard/peer-pad/issues/152#issuecomment-387812824,
this will give us access to two environments:

| Branch | Environment | URL |
| ------------- |:-------------:| -----:|
| master | staging | https://dev.peerpad.net |
| production | prod | https://peerpad.net |