### PR TITLE
fix: editor should no longer break when changing viewmode

### DIFF
--- a/src/components/Edit.js
+++ b/src/components/Edit.js
@@ -243,6 +243,14 @@ class Edit extends Component {
     )
   }
 
+  componentDidUpdate () {
+    // Force codemirror to update to help avoid render / write order issues
+    if (this._editor && this._editor.refresh) {
+      this._editor.refresh()
+      this._editor.setOption('readOnly', !this.state.canEdit)
+    }
+  }
+
   async componentDidMount () {
     const docScript = await (await window.fetch('static/js/viewer.bundle.js')).text()
 
@@ -309,8 +317,6 @@ class Edit extends Component {
           this._editor.enable()
           this._editor.focus()
           break
-        default:
-          this._editor.setOption('readOnly', false)
       }
     }
   }


### PR DESCRIPTION
Resolves https://github.com/ipfs-shipyard/peer-pad/issues/197

This also fixes an issue where joining an existing peer-pad could prevent editing.