### PR TITLE
Fix for applying diffs against codemirror

### DIFF
--- a/src/lib/bind-editor.js
+++ b/src/lib/bind-editor.js
@@ -93,6 +93,7 @@ const bindCodeMirror = (doc, titleEditor, editor) => {
             if (pos < cursorPos) {
               cursorPos += text.length
             }
+            pos += text.length
             moveMarkersIfAfter(pos, text.length)
           }
         }


### PR DESCRIPTION
The pos pointer wasn't being advanced when adding new characters,
causing subsequent parts of the diff to be applied incorrectly.

This was causing an infinite divergence as other peers amplified
the incorrect diff.