### PR TITLE
feat: add error reporting via rollbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "peerpad",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1496,6 +1496,11 @@
         "callsite": "1.0.0"
       }
     },
+    "big-integer": {
+      "version": "1.6.36",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
+      "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg=="
+    },
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
@@ -1666,11 +1671,18 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "boom": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.0.tgz",
-      "integrity": "sha1-K/8kpVVldn/ehp7ICDF+sQxI6WY=",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-7.2.2.tgz",
+      "integrity": "sha512-IFUbOa8PS7xqmhIjpeStwT3d09hGkNYQ6aj2iELSTxcVs2u0aKn1NzhkdUQSzsRg1FVkj3uit3I6mXQCBixw+A==",
       "requires": {
-        "hoek": "5.x.x"
+        "hoek": "6.x.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.0.2.tgz",
+          "integrity": "sha512-0RGPLkyxpsMJVj/iOCaJaIWFEch988eUicJJpRiQ+Or1CMvBXcoZPlSx9FhreDWw4hxMYy8xgTEdlsYQDTnxWA=="
+        }
       }
     },
     "borc": {
@@ -2640,6 +2652,175 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
       "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
     },
+    "cid-tool": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cid-tool/-/cid-tool-0.1.0.tgz",
+      "integrity": "sha512-lss0IzW2uiLm+W8St00N23+ySnCoFTD7qPZB1WqqOSvT5mzDG8Di9e5LmcaEkNfFXh7xAmlPZmJnvWxAjVPErg==",
+      "requires": {
+        "cids": "~0.5.3",
+        "explain-error": "^1.0.4",
+        "multibase": "~0.5.0",
+        "multihashes": "~0.4.14",
+        "yargs": "^12.0.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "decamelize": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+          "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+          "requires": {
+            "xregexp": "4.0.0"
+          }
+        },
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+          "requires": {
+            "invert-kv": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.0.1.tgz",
+          "integrity": "sha512-7g5e7dmXPtzcP4bgsZ8ixDVqA7oWYuEz4lOSujeWyliPai4gfVDiFIcwBg3aGCPnmSGfzOKTK3ccPn0CKv3DBw==",
+          "requires": {
+            "execa": "^0.10.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+          "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+        },
+        "yargs": {
+          "version": "12.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.2.tgz",
+          "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^2.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^10.1.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
+        }
+      }
+    },
     "cids": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/cids/-/cids-0.5.5.tgz",
@@ -2967,6 +3148,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
+    "console-polyfill": {
+      "version": "github:rollbar/console-polyfill#eab6ff9d2b7597fc2f259baa18100556bdb94dbe",
+      "from": "github:rollbar/console-polyfill#eab6ff9d2b7597fc2f259baa18100556bdb94dbe",
+      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -3442,9 +3628,9 @@
       }
     },
     "curriable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/curriable/-/curriable-1.1.0.tgz",
-      "integrity": "sha512-ka1Ds8tH/rbRdtEcHRpuzdhu1SwwuodP2KHaRSYQwf8LoV65sdR0heihP2KoitIqtCg+eAdAx970rxgAdCft/Q=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/curriable/-/curriable-1.2.2.tgz",
+      "integrity": "sha512-gCvU0Hl8EYScI0mPksUiI+kLEV5M9Cva357EWMQGwXI3vc9mBWv7VnqN90YfMhd8tyDuTxakzuZv7lAdPBozow=="
     },
     "cyclist": {
       "version": "0.2.2",
@@ -3478,40 +3664,40 @@
       "integrity": "sha512-6YOUFa/+lXklPO42RF4zIzzphG01Jp1eoWolzkQb6z5oVsSThLibZ63VmAze3KuIMTglFt551q8j0Zaswx5vGQ=="
     },
     "datastore-core": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-0.5.0.tgz",
-      "integrity": "sha512-H15EZOXLZXJRXTKQ2EQ6lms93fYXsFUgTWYjtJfsGyhs8MAEfjzoFM1HpP4l1/TiWSz2weslyl57M/q2U65sgw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-0.6.0.tgz",
+      "integrity": "sha512-xWMnzq4G3BQ12Nt5YYyYNGOO07pFUzPlphHJxkuwDD4NGR0pSwT4pHnTx+OndXDVsIHijTGGM8flKFE3196mvw==",
       "requires": {
         "async": "^2.6.1",
-        "interface-datastore": "~0.5.0",
+        "interface-datastore": "~0.6.0",
         "left-pad": "^1.3.0",
         "pull-many": "^1.0.8",
         "pull-stream": "^3.6.9"
       }
     },
     "datastore-fs": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-0.6.0.tgz",
-      "integrity": "sha512-/e2R+jxyR1ACzy3nzW02A0spUrBC525eeq0lVC0VDqdIO2qva1wCN5XDWwpmL7vxngSFGhzpKh42q58fT2YIOw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-0.7.0.tgz",
+      "integrity": "sha512-U8amTi/aWW391JYeFbIzjKtEqECXuMvDafD0XphsiaRKp0If4SwxgmlMn+y7BHlCRrf4/AYAwemVZBMBrSwIxA==",
       "requires": {
         "async": "^2.6.1",
-        "datastore-core": "~0.5.0",
+        "datastore-core": "~0.6.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.1.11",
-        "interface-datastore": "~0.5.0",
+        "interface-datastore": "~0.6.0",
         "mkdirp": "~0.5.1",
         "pull-stream": "^3.6.9",
         "write-file-atomic": "^2.3.0"
       }
     },
     "datastore-level": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-0.9.0.tgz",
-      "integrity": "sha512-BL2KE1P5xgYWFRsOdwPEpTwW6Ebpxnp3Ir6aAC5Era+zMS3Vtf14vn2q8cUMvc4GCo68iqL3pknT4Ds9/xFKMw==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-0.10.0.tgz",
+      "integrity": "sha512-2ZkfI3xwtRK50N7DKCu4TmohUev0gs2KIR27QaE12Zo32wNJMIHY1OV5AES/VCdC1N8raAr/JIgPAInnPb1yLQ==",
       "requires": {
-        "datastore-core": "~0.5.0",
+        "datastore-core": "~0.6.0",
         "encoding-down": "^5.0.4",
-        "interface-datastore": "~0.5.0",
+        "interface-datastore": "~0.6.0",
         "level-js": "github:timkuijsten/level.js#18e03adab34c49523be7d3d58fafb0c632f61303",
         "leveldown": "^3.0.2",
         "levelup": "^2.0.2",
@@ -3730,9 +3916,9 @@
       "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
     },
     "delta-crdts": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/delta-crdts/-/delta-crdts-0.5.1.tgz",
-      "integrity": "sha512-Nj7jBiZt8mxo5lrwGYgrY8CZqnYn2eSAoPmNMr9IxOM6edmKn36FKT7NzpMqqVpzMLk/DH2hT518QtNKEEFSiA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/delta-crdts/-/delta-crdts-0.5.2.tgz",
+      "integrity": "sha512-dfeLtGn8lebdjuposZwyzUKXS6Qs9/2nqyVVkl7Nn3nryWsYTGrPk6HmHFB6CiARJ07oXzw/0kSZrLSu2CSxjA==",
       "requires": {
         "array.prototype.flatmap": "^1.2.1",
         "cuid": "^2.1.1",
@@ -4321,6 +4507,15 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "error-stack-parser": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.3.tgz",
+      "integrity": "sha1-+tpuOpzSsOCA5tb8dRQYZJc081w=",
+      "dev": true,
+      "requires": {
+        "stackframe": "^0.3.1"
+      }
+    },
     "es-abstract": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
@@ -4788,9 +4983,9 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "ethereum-common": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
-      "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
+      "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
     },
     "ethereumjs-account": {
       "version": "2.0.5",
@@ -4803,16 +4998,21 @@
       }
     },
     "ethereumjs-block": {
-      "version": "1.7.1",
-      "resolved": "http://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
-      "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-2.1.0.tgz",
+      "integrity": "sha512-ip+x4/7hUInX+TQfhEKsQh9MJK1Dbjp4AuPjf1UdX3udAV4beYD4EMCNIPzBLCsGS8WQZYXLpo83tVTISYNpow==",
       "requires": {
         "async": "^2.0.1",
-        "ethereum-common": "0.2.0",
+        "ethereumjs-common": "^0.6.0",
         "ethereumjs-tx": "^1.2.2",
         "ethereumjs-util": "^5.0.0",
         "merkle-patricia-tree": "^2.1.2"
       }
+    },
+    "ethereumjs-common": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-0.6.0.tgz",
+      "integrity": "sha512-KN1BScZ6bMUIBMP7a2hNJYhpcY/TvXxU/9B0t9xOyytheIWOaJynVLwStma/oHICIlStSmfbwLvP0CPbek+IXQ=="
     },
     "ethereumjs-tx": {
       "version": "1.3.7",
@@ -4821,13 +5021,6 @@
       "requires": {
         "ethereum-common": "^0.0.18",
         "ethereumjs-util": "^5.0.0"
-      },
-      "dependencies": {
-        "ethereum-common": {
-          "version": "0.0.18",
-          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
-          "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8="
-        }
       }
     },
     "ethereumjs-util": {
@@ -4971,6 +5164,11 @@
       "requires": {
         "homedir-polyfill": "^1.0.1"
       }
+    },
+    "explain-error": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/explain-error/-/explain-error-1.0.4.tgz",
+      "integrity": "sha1-p5PTrAytTGq1cemWj7urbLJTKSk="
     },
     "express": {
       "version": "4.16.4",
@@ -5226,9 +5424,9 @@
       }
     },
     "file-type": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
-      "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ=="
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.4.0.tgz",
+      "integrity": "sha512-/Ha0T7TRFOFKgj36icy46h93By2tTwHirW9qeNLslo5NYmd7BbITVv2tkcuohmZWsNLqg9/dKNKwRXF3OVgVdA=="
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -5300,13 +5498,14 @@
       }
     },
     "find-process": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.1.4.tgz",
-      "integrity": "sha512-lC942sDHypboLEKaD7VUwp6laoSm2a1zbhNnLtCxgn0e71GlZtTiqOFIr2ooHIOHY8/zLnpihcfVUi89nG3JKg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/find-process/-/find-process-1.2.0.tgz",
+      "integrity": "sha512-K7nFxn8/ojEHbD4mkH3uNjcDhQrljjA6yHdBWTqjidFN6M44oBRak4f5RzfgQmTYx/m9+vo/975CGcBNChUIdg==",
       "requires": {
         "chalk": "^2.0.1",
         "commander": "^2.11.0",
-        "debug": "^2.6.8"
+        "debug": "^2.6.8",
+        "lodash": "^4.17.11"
       },
       "dependencies": {
         "chalk": {
@@ -5491,7 +5690,7 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-ext": {
-      "version": "github:baudehlo/node-fs-ext#7c9824f3dc330e795aa13359d96252860bd3a684",
+      "version": "github:baudehlo/node-fs-ext#2ba366d9fc67ef3ab165e239068924b276ecf249",
       "from": "github:baudehlo/node-fs-ext#master",
       "optional": true,
       "requires": {
@@ -7585,15 +7784,16 @@
       }
     },
     "interface-datastore": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.5.0.tgz",
-      "integrity": "sha512-JBQG5zCsh71DdDD01PzRrhlFBI0FCj6zAlJVBcnsZlfK74BK7Yx8f3SPxk240/JplrA919mjfrpe1W7BaovtRg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.6.0.tgz",
+      "integrity": "sha512-aDbjWsEdTHd2Yc2A8QOeAEWMwlWDwumVX24bE0/AE7XxfDveWuDUKP7HQito0u1c80FZmR+y/Op14um+cG0CSw==",
       "requires": {
         "async": "^2.6.1",
+        "class-is": "^1.1.0",
         "err-code": "^1.1.2",
         "pull-defer": "~0.2.3",
         "pull-stream": "^3.6.9",
-        "uuid": "^3.3.2"
+        "uuid": "^3.2.2"
       }
     },
     "internal-ip": {
@@ -7659,104 +7859,105 @@
       "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
     },
     "ipfs": {
-      "version": "0.32.3",
-      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.32.3.tgz",
-      "integrity": "sha512-5Huc2ykrTpALR+GDmo6WvNcji6y3tdwZQUeq125hZKBVGLSpQfV5Pqm2/0paJUH7eZEO4TpGgUMlFzg3vUDbeg==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.33.0.tgz",
+      "integrity": "sha512-gO7cB5OhVgiq+m4Adi/VhOnHZNBU/RThD3vDVBLyUucfFm0Mj+wmy8MZvG7+wljgg8NmQcVBd3wTDIu2OlSXPQ==",
       "requires": {
         "@nodeutils/defaults-deep": "^1.1.0",
         "async": "^2.6.1",
-        "big.js": "^5.1.2",
+        "big.js": "^5.2.2",
         "binary-querystring": "~0.1.2",
-        "bl": "^2.0.1",
+        "bl": "^2.1.2",
         "boom": "^7.2.0",
         "bs58": "^4.0.1",
         "byteman": "^1.3.5",
-        "cids": "~0.5.3",
-        "debug": "^3.1.0",
+        "cid-tool": "~0.1.0",
+        "cids": "~0.5.5",
+        "debug": "^4.1.0",
         "err-code": "^1.1.2",
-        "file-type": "^8.1.0",
-        "filesize": "^3.6.1",
+        "file-type": "^10.2.0",
         "fnv1a": "^1.0.1",
         "fsm-event": "^2.1.0",
         "get-folder-size": "^2.0.0",
-        "glob": "^7.1.2",
+        "glob": "^7.1.3",
         "hapi": "^16.6.2",
         "hapi-set-header": "^1.0.2",
-        "hoek": "^5.0.3",
+        "hoek": "^5.0.4",
         "human-to-milliseconds": "^1.0.0",
-        "interface-datastore": "~0.5.0",
-        "ipfs-api": "^24.0.0",
-        "ipfs-bitswap": "~0.20.3",
-        "ipfs-block": "~0.7.1",
-        "ipfs-block-service": "~0.14.0",
-        "ipfs-http-response": "~0.1.2",
-        "ipfs-mfs": "~0.4.0",
+        "interface-datastore": "~0.6.0",
+        "ipfs-api": "^26.1.0",
+        "ipfs-bitswap": "~0.21.0",
+        "ipfs-block": "~0.8.0",
+        "ipfs-block-service": "~0.15.1",
+        "ipfs-http-response": "~0.2.0",
+        "ipfs-mfs": "~0.4.2",
         "ipfs-multipart": "~0.1.0",
-        "ipfs-repo": "~0.24.0",
-        "ipfs-unixfs": "~0.1.15",
-        "ipfs-unixfs-engine": "~0.32.3",
-        "ipld": "~0.17.3",
-        "ipld-dag-cbor": "~0.12.1",
-        "ipld-dag-pb": "~0.14.6",
-        "ipns": "~0.2.0",
-        "is-ipfs": "~0.4.2",
+        "ipfs-repo": "~0.25.0",
+        "ipfs-unixfs": "~0.1.16",
+        "ipfs-unixfs-engine": "~0.33.0",
+        "ipld": "~0.19.1",
+        "ipld-bitcoin": "~0.1.8",
+        "ipld-dag-pb": "~0.14.11",
+        "ipld-ethereum": "^2.0.1",
+        "ipld-git": "~0.2.2",
+        "ipld-raw": "^2.0.1",
+        "ipld-zcash": "~0.1.6",
+        "ipns": "~0.3.0",
+        "is-ipfs": "~0.4.7",
         "is-pull-stream": "~0.0.0",
         "is-stream": "^1.1.0",
         "joi": "^13.4.0",
         "joi-browser": "^13.4.0",
         "joi-multiaddr": "^2.0.0",
-        "libp2p": "~0.23.0",
+        "libp2p": "~0.23.1",
         "libp2p-bootstrap": "~0.9.3",
-        "libp2p-circuit": "~0.2.0",
-        "libp2p-crypto": "~0.13.0",
-        "libp2p-floodsub": "~0.15.0",
-        "libp2p-kad-dht": "~0.10.1",
-        "libp2p-keychain": "~0.3.1",
+        "libp2p-crypto": "~0.14.0",
+        "libp2p-kad-dht": "~0.10.6",
+        "libp2p-keychain": "~0.3.3",
         "libp2p-mdns": "~0.12.0",
-        "libp2p-mplex": "~0.8.0",
-        "libp2p-record": "~0.5.1",
+        "libp2p-mplex": "~0.8.2",
+        "libp2p-record": "~0.6.0",
         "libp2p-secio": "~0.10.0",
-        "libp2p-tcp": "~0.12.0",
-        "libp2p-webrtc-star": "~0.15.3",
-        "libp2p-websocket-star": "~0.8.1",
+        "libp2p-tcp": "~0.13.0",
+        "libp2p-webrtc-star": "~0.15.5",
+        "libp2p-websocket-star": "~0.9.0",
         "libp2p-websockets": "~0.12.0",
-        "lodash": "^4.17.10",
-        "mafmt": "^6.0.0",
-        "mime-types": "^2.1.19",
+        "lodash": "^4.17.11",
+        "mafmt": "^6.0.2",
+        "mime-types": "^2.1.21",
         "mkdirp": "~0.5.1",
         "multiaddr": "^5.0.0",
         "multiaddr-to-uri": "^4.0.0",
         "multibase": "~0.5.0",
-        "multihashes": "~0.4.13",
+        "multihashes": "~0.4.14",
         "once": "^1.4.0",
-        "path-exists": "^3.0.0",
         "peer-book": "~0.8.0",
-        "peer-id": "~0.11.0",
+        "peer-id": "~0.12.0",
         "peer-info": "~0.14.1",
-        "progress": "^2.0.0",
-        "prom-client": "^11.1.1",
-        "prometheus-gc-stats": "~0.5.1",
+        "progress": "^2.0.1",
+        "prom-client": "^11.1.3",
+        "prometheus-gc-stats": "~0.6.0",
         "promisify-es6": "^1.0.3",
         "pull-abortable": "^4.1.1",
-        "pull-defer": "~0.2.2",
+        "pull-catch": "^1.0.0",
+        "pull-defer": "~0.2.3",
         "pull-file": "^1.1.0",
         "pull-ndjson": "~0.1.1",
         "pull-paramap": "^1.2.2",
         "pull-pushable": "^2.2.0",
         "pull-sort": "^1.0.1",
-        "pull-stream": "^3.6.8",
+        "pull-stream": "^3.6.9",
         "pull-stream-to-stream": "^1.3.4",
         "pull-zip": "^2.0.1",
+        "pump": "^3.0.0",
         "read-pkg-up": "^4.0.0",
-        "readable-stream": "2.3.6",
+        "readable-stream": "3.0.6",
         "receptacle": "^1.3.2",
         "stream-to-pull-stream": "^1.7.2",
-        "tar-stream": "^1.6.1",
+        "tar-stream": "^1.6.2",
         "temp": "~0.8.3",
-        "through2": "^2.0.3",
         "update-notifier": "^2.5.0",
-        "yargs": "^12.0.1",
-        "yargs-parser": "^10.1.0",
+        "yargs": "^12.0.2",
         "yargs-promise": "^1.1.0"
       },
       "dependencies": {
@@ -7798,9 +7999,9 @@
           }
         },
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -7840,6 +8041,53 @@
           "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
           "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
         },
+        "ipfs-api": {
+          "version": "26.1.2",
+          "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-26.1.2.tgz",
+          "integrity": "sha512-HkM6vQOHL9z9ZCXIrbDXvAOsIzfWPaAac9kY+SjUuVqMydWHzP8qTxfv5jaXResGbmLcbwcROhuqgJU+HrclSg==",
+          "requires": {
+            "async": "^2.6.1",
+            "big.js": "^5.2.2",
+            "bl": "^2.1.2",
+            "bs58": "^4.0.1",
+            "cids": "~0.5.5",
+            "concat-stream": "^1.6.2",
+            "debug": "^4.1.0",
+            "detect-node": "^2.0.4",
+            "end-of-stream": "^1.4.1",
+            "flatmap": "0.0.3",
+            "glob": "^7.1.3",
+            "ipfs-block": "~0.8.0",
+            "ipfs-unixfs": "~0.1.16",
+            "ipld-dag-cbor": "~0.13.0",
+            "ipld-dag-pb": "~0.14.11",
+            "is-ipfs": "~0.4.7",
+            "is-pull-stream": "0.0.0",
+            "is-stream": "^1.1.0",
+            "libp2p-crypto": "~0.14.0",
+            "lodash": "^4.17.11",
+            "lru-cache": "^4.1.3",
+            "multiaddr": "^5.0.0",
+            "multibase": "~0.5.0",
+            "multihashes": "~0.4.14",
+            "ndjson": "^1.5.0",
+            "once": "^1.4.0",
+            "peer-id": "~0.12.0",
+            "peer-info": "~0.14.1",
+            "promisify-es6": "^1.0.3",
+            "pull-defer": "~0.2.3",
+            "pull-pushable": "^2.2.0",
+            "pull-stream-to-stream": "^1.3.4",
+            "pump": "^3.0.0",
+            "qs": "^6.5.2",
+            "readable-stream": "^3.0.6",
+            "stream-http": "^3.0.0",
+            "stream-to-pull-stream": "^1.7.2",
+            "streamifier": "~0.1.1",
+            "tar-stream": "^1.6.2",
+            "through2": "^2.0.3"
+          }
+        },
         "lcid": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -7848,62 +8096,25 @@
             "invert-kv": "^2.0.0"
           }
         },
-        "libp2p-websocket-star": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/libp2p-websocket-star/-/libp2p-websocket-star-0.8.1.tgz",
-          "integrity": "sha512-lDzL9fGWXveu6HEc6xuIEi036Bg1IQ+PliJJHxgSS9ozTkUwMT5dfvyugSWsZ7Gh4q7BYzr5cDZCNkR42GcRZw==",
+        "libp2p-crypto": {
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.14.1.tgz",
+          "integrity": "sha512-JP3bfEzNik76fFIWOeU909+v76tjj5BMukbPCc61bgh1ixftcHkr4bH79duz+oSxRpGA+orCLxvkhgALV+pfwg==",
           "requires": {
+            "asn1.js": "^5.0.1",
             "async": "^2.6.1",
-            "class-is": "^1.1.0",
-            "data-queue": "0.0.3",
-            "debug": "^3.1.0",
-            "interface-connection": "~0.3.2",
-            "libp2p-crypto": "~0.13.0",
-            "mafmt": "^6.0.0",
-            "merge-recursive": "0.0.3",
-            "multiaddr": "^5.0.0",
-            "once": "^1.4.0",
-            "peer-id": "~0.10.7",
-            "peer-info": "~0.14.1",
-            "pull-stream": "^3.6.8",
-            "socket.io-client": "^2.1.1",
-            "socket.io-pull-stream": "~0.1.5",
-            "uuid": "^3.2.1"
-          },
-          "dependencies": {
-            "peer-id": {
-              "version": "0.10.7",
-              "resolved": "http://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
-              "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
-              "requires": {
-                "async": "^2.6.0",
-                "libp2p-crypto": "~0.12.1",
-                "lodash": "^4.17.5",
-                "multihashes": "~0.4.13"
-              },
-              "dependencies": {
-                "libp2p-crypto": {
-                  "version": "0.12.1",
-                  "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
-                  "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
-                  "requires": {
-                    "asn1.js": "^5.0.0",
-                    "async": "^2.6.0",
-                    "browserify-aes": "^1.1.1",
-                    "bs58": "^4.0.1",
-                    "keypair": "^1.0.1",
-                    "libp2p-crypto-secp256k1": "~0.2.2",
-                    "multihashing-async": "~0.4.7",
-                    "node-forge": "^0.7.1",
-                    "pem-jwk": "^1.5.1",
-                    "protons": "^1.0.1",
-                    "rsa-pem-to-jwk": "^1.1.3",
-                    "tweetnacl": "^1.0.0",
-                    "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
-                  }
-                }
-              }
-            }
+            "browserify-aes": "^1.2.0",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.5.1",
+            "node-forge": "~0.7.6",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "ursa-optional": "~0.9.9",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           }
         },
         "load-json-file": {
@@ -7930,6 +8141,19 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "multihashing-async": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.1.tgz",
+          "integrity": "sha512-Ft5lQNcJCfsns1QN1TDXqPZrrNwBYqIokprYJR2h2Jj01x0GFcYmJYAqHvme6vJoyI3XptEcmZpdr9g5Oy7q3Q==",
+          "requires": {
+            "async": "^2.6.1",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
         },
         "os-locale": {
           "version": "3.0.1",
@@ -7979,17 +8203,6 @@
             "pify": "^3.0.0"
           }
         },
-        "peer-id": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.11.0.tgz",
-          "integrity": "sha512-C/lRJk4CWIgOdKvfO572NvHbPcUwe49I6G0toIhDB5tCohqv/qzy0uBcAK9Ww8TvYI6U4J3C8ACShV9fWjNU4w==",
-          "requires": {
-            "async": "^2.6.1",
-            "libp2p-crypto": "~0.13.0",
-            "lodash": "^4.17.10",
-            "multihashes": "~0.4.13"
-          }
-        },
         "read-pkg": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -8009,6 +8222,27 @@
             "read-pkg": "^3.0.0"
           }
         },
+        "readable-stream": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
+          "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "stream-http": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.0.0.tgz",
+          "integrity": "sha512-JELJfd+btL9GHtxU3+XXhg9NLYrKFnhybfvRuDghtyVkOFydz3PKNT1df07AMr88qW03WHF+FSV0PySpXignCA==",
+          "requires": {
+            "builtin-status-codes": "^3.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^3.0.6",
+            "xtend": "^4.0.0"
+          }
+        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -8026,6 +8260,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "ursa-optional": {
+          "version": "0.9.10",
+          "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.9.10.tgz",
+          "integrity": "sha512-RvEbhnxlggX4MXon7KQulTFiJQtLJZpSb9ZSa7ZTkOW0AzqiVTaLjI4vxaSzJBDH9dwZ3ltZadFiBaZslp6haA==",
+          "requires": {
+            "bindings": "^1.3.0",
+            "nan": "^2.11.1"
+          }
         },
         "which-module": {
           "version": "2.0.0",
@@ -8062,12 +8305,13 @@
       }
     },
     "ipfs-api": {
-      "version": "24.0.2",
-      "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-24.0.2.tgz",
-      "integrity": "sha512-3uxSZ+KNlQql3HO//gfR2Q+MTrfcmkLPlGP9Ewv28Ri+IEUZ3oawo9JahWCEGvXrnJmpRpD9Ko8dYHQZTq+3bA==",
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-25.0.0.tgz",
+      "integrity": "sha512-s+UYe+ZOkxSxU/J0O731HhuzXlmrpGoe1apj97p0yM8oLo0w1EzgWYe+0gV6A0+15cLsgREBD130gJFDGDw6dg==",
       "requires": {
         "async": "^2.6.1",
         "big.js": "^5.1.2",
+        "bl": "^2.0.1",
         "bs58": "^4.0.1",
         "cids": "~0.5.3",
         "concat-stream": "^1.6.2",
@@ -8083,6 +8327,7 @@
         "is-pull-stream": "0.0.0",
         "is-stream": "^1.1.0",
         "libp2p-crypto": "~0.13.0",
+        "lodash": "^4.17.11",
         "lru-cache": "^4.1.3",
         "multiaddr": "^5.0.0",
         "multibase": "~0.4.0",
@@ -8098,7 +8343,7 @@
         "pump": "^3.0.0",
         "qs": "^6.5.2",
         "readable-stream": "^2.3.6",
-        "stream-http": "^2.8.3",
+        "stream-http": "^3.0.0",
         "stream-to-pull-stream": "^1.7.2",
         "streamifier": "~0.1.1",
         "tar-stream": "^1.6.1"
@@ -8117,6 +8362,30 @@
             "ms": "^2.1.1"
           }
         },
+        "ipfs-block": {
+          "version": "0.7.1",
+          "resolved": "http://registry.npmjs.org/ipfs-block/-/ipfs-block-0.7.1.tgz",
+          "integrity": "sha512-ABZS9J/+OaDwc10zu6pIVdxWnOD/rkPEravk7FRVuRep7/zKSjffNhO/WuHN7Ex+MOBMz7mty0e+i6xjGnRsRQ==",
+          "requires": {
+            "cids": "^0.5.3",
+            "class-is": "^1.1.0"
+          }
+        },
+        "ipld-dag-cbor": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.12.1.tgz",
+          "integrity": "sha512-m0BR/zR9sKIuY/PydppkpwO0S9w7+ob0as7RN3jQmMIpW9m8HW7hLznvtp1xpYZknH7efUhIaMHgaQP43E5IWQ==",
+          "requires": {
+            "async": "^2.6.0",
+            "borc": "^2.0.2",
+            "bs58": "^4.0.1",
+            "cids": "~0.5.2",
+            "is-circular": "^1.0.1",
+            "multihashes": "~0.4.12",
+            "multihashing-async": "~0.5.1",
+            "traverse": "~0.6.6"
+          }
+        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -8130,6 +8399,19 @@
             "base-x": "3.0.4"
           }
         },
+        "multihashing-async": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.1.tgz",
+          "integrity": "sha512-Ft5lQNcJCfsns1QN1TDXqPZrrNwBYqIokprYJR2h2Jj01x0GFcYmJYAqHvme6vJoyI3XptEcmZpdr9g5Oy7q3Q==",
+          "requires": {
+            "async": "^2.6.1",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
         "peer-id": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.11.0.tgz",
@@ -8140,19 +8422,42 @@
             "lodash": "^4.17.10",
             "multihashes": "~0.4.13"
           }
+        },
+        "stream-http": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.0.0.tgz",
+          "integrity": "sha512-JELJfd+btL9GHtxU3+XXhg9NLYrKFnhybfvRuDghtyVkOFydz3PKNT1df07AMr88qW03WHF+FSV0PySpXignCA==",
+          "requires": {
+            "builtin-status-codes": "^3.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^3.0.6",
+            "xtend": "^4.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "3.0.6",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
+              "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+              "requires": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+              }
+            }
+          }
         }
       }
     },
     "ipfs-bitswap": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-0.20.3.tgz",
-      "integrity": "sha512-qXg/QhevKBU/tKdWgW6yhcSKQDQx+4Mvv9HEeoVjkqZ9Pagmojk6yGk8X4J9H2G2PagvHXkWsqwqyKho7RcPWA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-0.21.0.tgz",
+      "integrity": "sha512-gsKGv3pa98jVQZURZcubW/LPpj0SX2UjISosF+7Nnmp4oR1RtTNBIhY+OyvlNGMWo8BqfVZb/iB0Z1+FME6CAw==",
       "requires": {
         "async": "^2.6.1",
-        "big.js": "^5.1.2",
-        "cids": "~0.5.3",
-        "debug": "^3.1.0",
-        "ipfs-block": "~0.7.1",
+        "big.js": "^5.2.2",
+        "cids": "~0.5.5",
+        "debug": "^4.1.0",
+        "ipfs-block": "~0.8.0",
         "lodash.debounce": "^4.0.8",
         "lodash.find": "^4.6.0",
         "lodash.groupby": "^4.6.0",
@@ -8166,10 +8471,10 @@
         "multicodec": "~0.2.7",
         "multihashing-async": "~0.5.1",
         "protons": "^1.0.1",
-        "pull-defer": "~0.2.2",
-        "pull-length-prefixed": "^1.3.0",
+        "pull-defer": "~0.2.3",
+        "pull-length-prefixed": "^1.3.1",
         "pull-pushable": "^2.2.0",
-        "pull-stream": "^3.6.8",
+        "pull-stream": "^3.6.9",
         "varint-decoder": "~0.1.1"
       },
       "dependencies": {
@@ -8179,9 +8484,9 @@
           "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
         },
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -8207,33 +8512,33 @@
       }
     },
     "ipfs-block": {
-      "version": "0.7.1",
-      "resolved": "http://registry.npmjs.org/ipfs-block/-/ipfs-block-0.7.1.tgz",
-      "integrity": "sha512-ABZS9J/+OaDwc10zu6pIVdxWnOD/rkPEravk7FRVuRep7/zKSjffNhO/WuHN7Ex+MOBMz7mty0e+i6xjGnRsRQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.8.0.tgz",
+      "integrity": "sha512-znNtFRxXlJYP1/Q4u0tGFJUceH9pNww8WA+zair6T3y7d28m+vtUDJGn96M7ZlFFSkByQyQsAiq2ssNhKtMzxw==",
       "requires": {
-        "cids": "^0.5.3",
+        "cids": "~0.5.5",
         "class-is": "^1.1.0"
       }
     },
     "ipfs-block-service": {
-      "version": "0.14.0",
-      "resolved": "http://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.14.0.tgz",
-      "integrity": "sha512-qu5VdBSAh/44wtqVgyoyWebjIY6mLbiEZObwYZHEZ5VFuU4oOlfZ+s2oz2I5lTw1eeL7SGccQeshQ0OePxIPnw=="
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.15.1.tgz",
+      "integrity": "sha512-t1p77Iq2Scr73mwIdY4d/00JqQmvGw2IdAXPfWi4PBzcU/bZwMDjBV4TPmANsl5oLMvHguiCHRSOhS+OSmZBsw=="
     },
     "ipfs-http-response": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.1.4.tgz",
-      "integrity": "sha512-qVi0AK3evZBbHljePgmeFy6o8RBVTOmPXUgRNHrwFr99DmJHPhbgJ/Wse0vpQsKwo3dd1m7RP33GHE9Xd1vmPA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.2.0.tgz",
+      "integrity": "sha512-E4atwGKflYNzynrJQ6VYguREiPWgQDmgXOwEsGOM8EdHHQWOkWsPNl6CGnlHGC2ESj0iUJx1CYMmXNmNzzOlGQ==",
       "requires": {
         "async": "^2.6.0",
-        "cids": "^0.5.3",
+        "cids": "~0.5.5",
         "debug": "^3.1.0",
         "file-type": "^8.0.0",
         "filesize": "^3.6.1",
         "get-stream": "^3.0.0",
-        "ipfs-unixfs": "^0.1.14",
+        "ipfs-unixfs": "~0.1.14",
         "mime-types": "^2.1.18",
-        "multihashes": "^0.4.13",
+        "multihashes": "~0.4.13",
         "promisify-es6": "^1.0.3",
         "stream-to-blob": "^1.0.1"
       },
@@ -8245,6 +8550,11 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "file-type": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
+          "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ=="
         },
         "ms": {
           "version": "2.1.1",
@@ -8292,23 +8602,51 @@
             "ms": "^2.1.1"
           }
         },
-        "interface-datastore": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.6.0.tgz",
-          "integrity": "sha512-aDbjWsEdTHd2Yc2A8QOeAEWMwlWDwumVX24bE0/AE7XxfDveWuDUKP7HQito0u1c80FZmR+y/Op14um+cG0CSw==",
+        "ipfs-unixfs-engine": {
+          "version": "0.32.8",
+          "resolved": "https://registry.npmjs.org/ipfs-unixfs-engine/-/ipfs-unixfs-engine-0.32.8.tgz",
+          "integrity": "sha512-YqLppNmG5M0rFj7QOTdRjny8xNKxmqKJE5DCOtc2ZMaXd4Semq+rEH23N2Mr1jYpimboDnadcv6jszi5cWRexw==",
           "requires": {
             "async": "^2.6.1",
-            "class-is": "^1.1.0",
-            "err-code": "^1.1.2",
-            "pull-defer": "~0.2.3",
+            "cids": "~0.5.5",
+            "deep-extend": "~0.6.0",
+            "ipfs-unixfs": "~0.1.15",
+            "ipld-dag-pb": "~0.14.6",
+            "left-pad": "^1.3.0",
+            "multihashing-async": "~0.5.1",
+            "pull-batch": "^1.0.0",
+            "pull-block": "^1.4.0",
+            "pull-cat": "^1.1.11",
+            "pull-pair": "^1.1.0",
+            "pull-paramap": "^1.2.2",
+            "pull-pause": "0.0.2",
+            "pull-pushable": "^2.2.0",
             "pull-stream": "^3.6.9",
-            "uuid": "^3.2.2"
+            "pull-through": "^1.0.18",
+            "pull-traverse": "^1.0.3",
+            "pull-write": "^1.1.4",
+            "rabin": "^1.6.0",
+            "sparse-array": "^1.3.1",
+            "stream-to-pull-stream": "^1.7.2"
           }
         },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "multihashing-async": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.1.tgz",
+          "integrity": "sha512-Ft5lQNcJCfsns1QN1TDXqPZrrNwBYqIokprYJR2h2Jj01x0GFcYmJYAqHvme6vJoyI3XptEcmZpdr9g5Oy7q3Q==",
+          "requires": {
+            "async": "^2.6.1",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
         }
       }
     },
@@ -8322,26 +8660,26 @@
       }
     },
     "ipfs-repo": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-0.24.0.tgz",
-      "integrity": "sha512-dbLuqHVK+RIsDHmbk7oxySMJNRz/PIROgIe5vjQKRqZyuNdh9gFTUsUEvEDsfMUgPhnS9cnf53YAR2B+EuMUrA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-0.25.0.tgz",
+      "integrity": "sha512-P/QGkWTaI5Vp9HLQssCkxhmbu0uZ3fINQWooSAAk3Kp647OIgXC5CWXALA/xlxAsyn1PxqlHZ9yLFOc8eJP5wg==",
       "requires": {
-        "async": "^2.6.0",
+        "async": "^2.6.1",
         "base32.js": "~0.1.0",
-        "big.js": "^5.0.3",
-        "cids": "~0.5.3",
-        "datastore-core": "~0.5.0",
-        "datastore-fs": "~0.6.0",
-        "datastore-level": "~0.9.0",
-        "debug": "^3.1.0",
-        "interface-datastore": "~0.5.0",
+        "big.js": "^5.2.2",
+        "cids": "~0.5.5",
+        "datastore-core": "~0.6.0",
+        "datastore-fs": "~0.7.0",
+        "datastore-level": "~0.10.0",
+        "debug": "^4.1.0",
+        "interface-datastore": "~0.6.0",
         "ipfs-block": "~0.7.1",
         "lock-me": "^1.0.4",
         "lodash.get": "^4.4.2",
         "lodash.has": "^4.5.2",
         "lodash.set": "^4.3.2",
-        "multiaddr": "^4.0.0",
-        "pull-stream": "^3.6.7",
+        "multiaddr": "^5.0.0",
+        "pull-stream": "^3.6.9",
         "sort-keys": "^2.0.0"
       },
       "dependencies": {
@@ -8351,32 +8689,26 @@
           "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
         },
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
           "requires": {
             "ms": "^2.1.1"
+          }
+        },
+        "ipfs-block": {
+          "version": "0.7.1",
+          "resolved": "http://registry.npmjs.org/ipfs-block/-/ipfs-block-0.7.1.tgz",
+          "integrity": "sha512-ABZS9J/+OaDwc10zu6pIVdxWnOD/rkPEravk7FRVuRep7/zKSjffNhO/WuHN7Ex+MOBMz7mty0e+i6xjGnRsRQ==",
+          "requires": {
+            "cids": "^0.5.3",
+            "class-is": "^1.1.0"
           }
         },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        },
-        "multiaddr": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
-          "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "ip": "^1.1.5",
-            "ip-address": "^5.8.9",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
-          }
         },
         "sort-keys": {
           "version": "2.0.0",
@@ -8397,15 +8729,15 @@
       }
     },
     "ipfs-unixfs-engine": {
-      "version": "0.32.8",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-engine/-/ipfs-unixfs-engine-0.32.8.tgz",
-      "integrity": "sha512-YqLppNmG5M0rFj7QOTdRjny8xNKxmqKJE5DCOtc2ZMaXd4Semq+rEH23N2Mr1jYpimboDnadcv6jszi5cWRexw==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-engine/-/ipfs-unixfs-engine-0.33.0.tgz",
+      "integrity": "sha512-NF4e9PB4I22Ca1qaGeCG0pBQOaYTpBWwgC+EKlAomwj6FD6BeFD4OpoaEAs9kp8dOdjY8yKrHe+tRg9AGgOoIw==",
       "requires": {
         "async": "^2.6.1",
         "cids": "~0.5.5",
         "deep-extend": "~0.6.0",
-        "ipfs-unixfs": "~0.1.15",
-        "ipld-dag-pb": "~0.14.6",
+        "ipfs-unixfs": "~0.1.16",
+        "ipld-dag-pb": "~0.14.11",
         "left-pad": "^1.3.0",
         "multihashing-async": "~0.5.1",
         "pull-batch": "^1.0.0",
@@ -8440,30 +8772,21 @@
       }
     },
     "ipld": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.17.4.tgz",
-      "integrity": "sha512-V+qGqt3CWYb72GzjSUQiPnzv7wLKDazB3zEBuiJmbVAta8RaoCuqb8cbmYN1riIW0pERRHqinrkNPdP9pZgkNA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.19.2.tgz",
+      "integrity": "sha512-pLOcibMaUGeXeSJJPqv20Jd57R4gN4bIic2jfiqQL67H0dSAoVSng3lP+W6Wv06U+m58+zCZnKnZxLkAmNTk8g==",
       "requires": {
         "async": "^2.6.1",
-        "cids": "~0.5.4",
-        "interface-datastore": "~0.5.0",
-        "ipfs-block": "~0.7.1",
-        "ipfs-block-service": "~0.14.0",
-        "ipfs-repo": "~0.24.0",
-        "ipld-bitcoin": "~0.1.7",
-        "ipld-dag-cbor": "~0.12.1",
-        "ipld-dag-pb": "~0.14.10",
-        "ipld-ethereum": "^2.0.1",
-        "ipld-git": "~0.2.1",
+        "cids": "~0.5.5",
+        "interface-datastore": "~0.6.0",
+        "ipfs-block": "~0.8.0",
+        "ipfs-block-service": "~0.15.0",
+        "ipfs-repo": "~0.25.0",
+        "ipld-dag-cbor": "~0.13.0",
+        "ipld-dag-pb": "~0.14.11",
         "ipld-raw": "^2.0.1",
-        "ipld-zcash": "~0.1.6",
-        "is-ipfs": "~0.4.2",
-        "lodash.flatten": "^4.4.0",
-        "lodash.includes": "^4.3.0",
-        "memdown": "^3.0.0",
-        "multihashes": "~0.4.14",
+        "merge-options": "^1.0.1",
         "pull-defer": "~0.2.3",
-        "pull-sort": "^1.0.1",
         "pull-stream": "^3.6.9",
         "pull-traverse": "^1.0.3"
       }
@@ -8497,16 +8820,16 @@
       }
     },
     "ipld-dag-cbor": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.12.1.tgz",
-      "integrity": "sha512-m0BR/zR9sKIuY/PydppkpwO0S9w7+ob0as7RN3jQmMIpW9m8HW7hLznvtp1xpYZknH7efUhIaMHgaQP43E5IWQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.13.0.tgz",
+      "integrity": "sha512-74gtitUOWbLkGtqomhq7lDYwWzfFNwbwMXAj3jpti4ZtfM9VTJWVIQ+05u7NOCj8yaLwzFONHdcO0rJ+j/i0jA==",
       "requires": {
-        "async": "^2.6.0",
-        "borc": "^2.0.2",
+        "async": "^2.6.1",
+        "borc": "^2.0.3",
         "bs58": "^4.0.1",
-        "cids": "~0.5.2",
-        "is-circular": "^1.0.1",
-        "multihashes": "~0.4.12",
+        "cids": "~0.5.5",
+        "is-circular": "^1.0.2",
+        "multihashes": "~0.4.14",
         "multihashing-async": "~0.5.1",
         "traverse": "~0.6.6"
       },
@@ -8559,28 +8882,33 @@
       }
     },
     "ipld-ethereum": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-2.0.1.tgz",
-      "integrity": "sha512-p+OIsTg7+NeXnE2Uq7g5HV7KVbJTQ9kVHSywOAUxUfj6loJb+6ReTCRrayQ+SbIXuVVVIVPU8OOUoGaugwFEjg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-2.0.2.tgz",
+      "integrity": "sha512-tKkoBL/Vg4rPJeZu4azbL8t/y6rcF2kfD5kMJ+J/r4Gu+cXkocN9i+A619/00jb+fonm2DgJOtMoSbBk5QfN0Q==",
       "requires": {
         "async": "^2.6.0",
         "cids": "~0.5.2",
         "ethereumjs-account": "^2.0.4",
-        "ethereumjs-block": "^1.7.1",
+        "ethereumjs-block": "^2.0.0",
         "ethereumjs-tx": "^1.3.3",
-        "ipfs-block": "~0.6.1",
+        "ipfs-block": "~0.8.0",
         "merkle-patricia-tree": "^2.2.0",
         "multihashes": "~0.4.12",
-        "multihashing-async": "~0.4.7",
+        "multihashing-async": "~0.5.1",
         "rlp": "^2.0.0"
       },
       "dependencies": {
-        "ipfs-block": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.6.1.tgz",
-          "integrity": "sha512-28dgGsb2YsYnFs+To4cVBX8e/lTCb8eWDzGhN5csj3a/sHMOYrHeK8+Ez0IV67CI3lqKGuG/ZD01Cmd6JUvKrQ==",
+        "multihashing-async": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.1.tgz",
+          "integrity": "sha512-Ft5lQNcJCfsns1QN1TDXqPZrrNwBYqIokprYJR2h2Jj01x0GFcYmJYAqHvme6vJoyI3XptEcmZpdr9g5Oy7q3Q==",
           "requires": {
-            "cids": "^0.5.2"
+            "async": "^2.6.1",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
           }
         }
       }
@@ -8666,14 +8994,14 @@
       }
     },
     "ipns": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/ipns/-/ipns-0.2.3.tgz",
-      "integrity": "sha512-F+T6c7St08eDuXmBNO0tzis3Y+Hohj6ld/EmQoAVQB+hIJeutPJNKYrBissZVe+7TVGnXvWtLnxJejoW7tk1mA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-0.3.0.tgz",
+      "integrity": "sha512-3X8xS4AVgRbsqaTfpJ4OzqAJ2DOYXl9lh7AV/gq7qyF14A+YXk1zmCKc6xXS2GJSVkvsnoRsVGPRrQnDQoNksw==",
       "requires": {
         "base32-encode": "^1.1.0",
         "big.js": "^5.1.2",
         "debug": "^3.1.0",
-        "interface-datastore": "~0.5.0",
+        "interface-datastore": "~0.6.0",
         "left-pad": "^1.3.0",
         "libp2p-crypto": "~0.13.0",
         "multihashes": "~0.4.14",
@@ -9565,11 +9893,18 @@
           }
         },
         "topo": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
-          "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.3.tgz",
+          "integrity": "sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==",
           "requires": {
-            "hoek": "5.x.x"
+            "hoek": "6.x.x"
+          },
+          "dependencies": {
+            "hoek": {
+              "version": "6.0.2",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.0.2.tgz",
+              "integrity": "sha512-0RGPLkyxpsMJVj/iOCaJaIWFEch988eUicJJpRiQ+Or1CMvBXcoZPlSx9FhreDWw4hxMYy8xgTEdlsYQDTnxWA=="
+            }
           }
         }
       }
@@ -9590,7 +9925,7 @@
       "dependencies": {
         "multiaddr": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
           "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
           "requires": {
             "bs58": "^4.0.1",
@@ -10376,47 +10711,6 @@
             "ms": "^2.1.1"
           }
         },
-        "interface-datastore": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.6.0.tgz",
-          "integrity": "sha512-aDbjWsEdTHd2Yc2A8QOeAEWMwlWDwumVX24bE0/AE7XxfDveWuDUKP7HQito0u1c80FZmR+y/Op14um+cG0CSw==",
-          "requires": {
-            "async": "^2.6.1",
-            "class-is": "^1.1.0",
-            "err-code": "^1.1.2",
-            "pull-defer": "~0.2.3",
-            "pull-stream": "^3.6.9",
-            "uuid": "^3.2.2"
-          }
-        },
-        "libp2p-record": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/libp2p-record/-/libp2p-record-0.6.0.tgz",
-          "integrity": "sha512-0hAAkyU4jyJoktUserbbg5OVwt+leXIyPsfdoJCbUrVnj1jLMZz5OG38qxSacyqmsZ4iln6D7ttIjZZPwaOp1A==",
-          "requires": {
-            "async": "^2.5.0",
-            "buffer-split": "^1.0.0",
-            "left-pad": "^1.1.3",
-            "multihashes": "~0.4.14",
-            "multihashing-async": "~0.4.6",
-            "protons": "^1.0.0"
-          },
-          "dependencies": {
-            "multihashing-async": {
-              "version": "0.4.8",
-              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.4.8.tgz",
-              "integrity": "sha512-LCc4lfxmTJOHKIjZjFNgvmfB6nXS/ErLInT9uwU8udFrRm2PH+aTPk3mfCREKmCiSHOlCWiv2O8rlnBx+OjlMw==",
-              "requires": {
-                "async": "^2.6.0",
-                "blakejs": "^1.1.0",
-                "js-sha3": "^0.7.0",
-                "multihashes": "~0.4.13",
-                "murmurhash3js": "^3.0.1",
-                "nodeify": "^1.0.1"
-              }
-            }
-          }
-        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -10459,21 +10753,6 @@
         "lodash": "^4.6.1",
         "pull-stream": "^3.6.8",
         "sanitize-filename": "^1.6.1"
-      },
-      "dependencies": {
-        "interface-datastore": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.6.0.tgz",
-          "integrity": "sha512-aDbjWsEdTHd2Yc2A8QOeAEWMwlWDwumVX24bE0/AE7XxfDveWuDUKP7HQito0u1c80FZmR+y/Op14um+cG0CSw==",
-          "requires": {
-            "async": "^2.6.1",
-            "class-is": "^1.1.0",
-            "err-code": "^1.1.2",
-            "pull-defer": "~0.2.3",
-            "pull-stream": "^3.6.9",
-            "uuid": "^3.2.2"
-          }
-        }
       }
     },
     "libp2p-mdns": {
@@ -10488,6 +10767,14 @@
         "peer-info": "~0.14.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
         "libp2p-crypto": {
           "version": "0.12.1",
           "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
@@ -10507,6 +10794,45 @@
             "tweetnacl": "^1.0.0",
             "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           }
+        },
+        "libp2p-tcp": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.12.1.tgz",
+          "integrity": "sha512-Vt1gLoOKAPAsgQ9IDwrwL4F5zA3gINsstwKKGgZaN5Boj/EeGghdug6vOL0TP2UKWudCuC2rCQUCPVOKZ5gYow==",
+          "requires": {
+            "class-is": "^1.1.0",
+            "debug": "^3.1.0",
+            "interface-connection": "~0.3.2",
+            "ip-address": "^5.8.9",
+            "lodash.includes": "^4.3.0",
+            "lodash.isfunction": "^3.0.9",
+            "mafmt": "^6.0.0",
+            "multiaddr": "^4.0.0",
+            "once": "^1.4.0",
+            "stream-to-pull-stream": "^1.7.2"
+          },
+          "dependencies": {
+            "multiaddr": {
+              "version": "4.0.0",
+              "resolved": "http://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
+              "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
+              "requires": {
+                "bs58": "^4.0.1",
+                "class-is": "^1.1.0",
+                "ip": "^1.1.5",
+                "ip-address": "^5.8.9",
+                "lodash.filter": "^4.6.0",
+                "lodash.map": "^4.6.0",
+                "varint": "^5.0.0",
+                "xtend": "^4.0.1"
+              }
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
         "peer-id": {
           "version": "0.10.7",
@@ -10573,111 +10899,123 @@
       }
     },
     "libp2p-ping": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/libp2p-ping/-/libp2p-ping-0.8.0.tgz",
-      "integrity": "sha512-7GtCCvbs6sEabnjh2ZIdru8wuKP4Qux6alw7wuaMosqWkPeFnnFmQsGaWEGpwEmD49A1dsT+aIYvAx5jFB02Bw==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/libp2p-ping/-/libp2p-ping-0.8.2.tgz",
+      "integrity": "sha512-QXcMAKCcPYKie5EbPB1VuFrA62/XrVVjIs5NUoJaEke2Ij5Xq+RISpCbSrmj5YFYa53q5uJ0l1wKYx0WPm6r0A==",
       "requires": {
-        "libp2p-crypto": "~0.13.0",
+        "libp2p-crypto": "~0.14.0",
         "pull-handshake": "^1.1.4",
-        "pull-stream": "^3.6.7"
-      }
-    },
-    "libp2p-record": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/libp2p-record/-/libp2p-record-0.5.1.tgz",
-      "integrity": "sha512-e2qLv0Tx4yBrGQrTbogWKpRFAM5rhmwTAnm/IfVn8/TzRBcB4F0PTVRB/Wf0eFCa8dNmD6vTn9wyhe+zmcI1zQ==",
-      "requires": {
-        "async": "^2.5.0",
-        "buffer-split": "^1.0.0",
-        "left-pad": "^1.1.3",
-        "multihashes": "~0.4.9",
-        "multihashing-async": "~0.4.6",
-        "peer-id": "~0.10.0",
-        "protons": "^1.0.0"
+        "pull-stream": "^3.6.9"
       },
       "dependencies": {
         "libp2p-crypto": {
-          "version": "0.12.1",
-          "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
-          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.14.1.tgz",
+          "integrity": "sha512-JP3bfEzNik76fFIWOeU909+v76tjj5BMukbPCc61bgh1ixftcHkr4bH79duz+oSxRpGA+orCLxvkhgALV+pfwg==",
           "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
+            "asn1.js": "^5.0.1",
+            "async": "^2.6.1",
+            "browserify-aes": "^1.2.0",
             "bs58": "^4.0.1",
             "keypair": "^1.0.1",
             "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
+            "multihashing-async": "~0.5.1",
+            "node-forge": "~0.7.6",
             "pem-jwk": "^1.5.1",
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
+            "ursa-optional": "~0.9.9",
             "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           }
         },
-        "peer-id": {
-          "version": "0.10.7",
-          "resolved": "http://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
-          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
+        "multihashing-async": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.1.tgz",
+          "integrity": "sha512-Ft5lQNcJCfsns1QN1TDXqPZrrNwBYqIokprYJR2h2Jj01x0GFcYmJYAqHvme6vJoyI3XptEcmZpdr9g5Oy7q3Q==",
           "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
+            "async": "^2.6.1",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
           }
         },
         "tweetnacl": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "ursa-optional": {
+          "version": "0.9.10",
+          "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.9.10.tgz",
+          "integrity": "sha512-RvEbhnxlggX4MXon7KQulTFiJQtLJZpSb9ZSa7ZTkOW0AzqiVTaLjI4vxaSzJBDH9dwZ3ltZadFiBaZslp6haA==",
+          "requires": {
+            "bindings": "^1.3.0",
+            "nan": "^2.11.1"
+          }
         }
       }
     },
-    "libp2p-secio": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.10.0.tgz",
-      "integrity": "sha512-/0nirr4UBdQBbETBliGYD6mLzKl+ZUX+2Kzmpk98Pdjdam5W2IhLF8zSeeK6Z4d/gJOaLdf2H8C6wLrwOSil8A==",
+    "libp2p-record": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/libp2p-record/-/libp2p-record-0.6.0.tgz",
+      "integrity": "sha512-0hAAkyU4jyJoktUserbbg5OVwt+leXIyPsfdoJCbUrVnj1jLMZz5OG38qxSacyqmsZ4iln6D7ttIjZZPwaOp1A==",
       "requires": {
-        "async": "^2.6.0",
-        "debug": "^3.1.0",
+        "async": "^2.5.0",
+        "buffer-split": "^1.0.0",
+        "left-pad": "^1.1.3",
+        "multihashes": "~0.4.14",
+        "multihashing-async": "~0.4.6",
+        "protons": "^1.0.0"
+      }
+    },
+    "libp2p-secio": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.10.1.tgz",
+      "integrity": "sha512-zfryPonQ2GMhGBaF28/fHK2luLFgCfK2NBX1hJBcX7FaxQI7vfNo11Ks3Dm0LIzoKLpFBOOyZqeJ3ewJi/pgnw==",
+      "requires": {
+        "async": "^2.6.1",
+        "debug": "^4.1.0",
         "interface-connection": "~0.3.2",
-        "libp2p-crypto": "~0.12.1",
-        "multihashing-async": "~0.4.8",
-        "peer-id": "~0.10.7",
-        "peer-info": "^0.14.0",
+        "libp2p-crypto": "~0.14.0",
+        "multihashing-async": "~0.5.1",
+        "peer-id": "~0.12.0",
+        "peer-info": "~0.14.1",
         "protons": "^1.0.1",
-        "pull-defer": "^0.2.2",
+        "pull-defer": "~0.2.3",
         "pull-handshake": "^1.1.4",
-        "pull-length-prefixed": "^1.3.0",
-        "pull-stream": "^3.6.7"
+        "pull-length-prefixed": "^1.3.1",
+        "pull-stream": "^3.6.9"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
           "requires": {
             "ms": "^2.1.1"
           }
         },
         "libp2p-crypto": {
-          "version": "0.12.1",
-          "resolved": "http://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.12.1.tgz",
-          "integrity": "sha512-1/z8rxZ0DcQNreZhEsl7PnLr7DWOioSvYbKBLGkRwNRiNh1JJLgh0PdTySBb44wkrOGT+TxcGRd7iq3/X6Wxwg==",
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.14.1.tgz",
+          "integrity": "sha512-JP3bfEzNik76fFIWOeU909+v76tjj5BMukbPCc61bgh1ixftcHkr4bH79duz+oSxRpGA+orCLxvkhgALV+pfwg==",
           "requires": {
-            "asn1.js": "^5.0.0",
-            "async": "^2.6.0",
-            "browserify-aes": "^1.1.1",
+            "asn1.js": "^5.0.1",
+            "async": "^2.6.1",
+            "browserify-aes": "^1.2.0",
             "bs58": "^4.0.1",
             "keypair": "^1.0.1",
             "libp2p-crypto-secp256k1": "~0.2.2",
-            "multihashing-async": "~0.4.7",
-            "node-forge": "^0.7.1",
+            "multihashing-async": "~0.5.1",
+            "node-forge": "~0.7.6",
             "pem-jwk": "^1.5.1",
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
+            "ursa-optional": "~0.9.9",
             "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           }
         },
@@ -10686,21 +11024,32 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
-        "peer-id": {
-          "version": "0.10.7",
-          "resolved": "http://registry.npmjs.org/peer-id/-/peer-id-0.10.7.tgz",
-          "integrity": "sha512-VEpMFcL9q0NQijmR0jsj38OGbY4yzaWMEareVkDahopmlNT+Cpsot8btPgsgBBApP9NiZj2Enwvh8rZN30ocQw==",
+        "multihashing-async": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.5.1.tgz",
+          "integrity": "sha512-Ft5lQNcJCfsns1QN1TDXqPZrrNwBYqIokprYJR2h2Jj01x0GFcYmJYAqHvme6vJoyI3XptEcmZpdr9g5Oy7q3Q==",
           "requires": {
-            "async": "^2.6.0",
-            "libp2p-crypto": "~0.12.1",
-            "lodash": "^4.17.5",
-            "multihashes": "~0.4.13"
+            "async": "^2.6.1",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
           }
         },
         "tweetnacl": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "ursa-optional": {
+          "version": "0.9.10",
+          "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.9.10.tgz",
+          "integrity": "sha512-RvEbhnxlggX4MXon7KQulTFiJQtLJZpSb9ZSa7ZTkOW0AzqiVTaLjI4vxaSzJBDH9dwZ3ltZadFiBaZslp6haA==",
+          "requires": {
+            "bindings": "^1.3.0",
+            "nan": "^2.11.1"
+          }
         }
       }
     },
@@ -10759,9 +11108,9 @@
       }
     },
     "libp2p-tcp": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.12.1.tgz",
-      "integrity": "sha512-Vt1gLoOKAPAsgQ9IDwrwL4F5zA3gINsstwKKGgZaN5Boj/EeGghdug6vOL0TP2UKWudCuC2rCQUCPVOKZ5gYow==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.13.0.tgz",
+      "integrity": "sha512-bsmfxi+uVegK61x9UxBEgWtvujPl+zwzuVEyaVRs2IxHu6OE5MGKnj7AflzlK4e3w2HZn8nm4qwMV5m+fhqK1g==",
       "requires": {
         "class-is": "^1.1.0",
         "debug": "^3.1.0",
@@ -10769,8 +11118,8 @@
         "ip-address": "^5.8.9",
         "lodash.includes": "^4.3.0",
         "lodash.isfunction": "^3.0.9",
-        "mafmt": "^6.0.0",
-        "multiaddr": "^4.0.0",
+        "mafmt": "^6.0.2",
+        "multiaddr": "^5.0.0",
         "once": "^1.4.0",
         "stream-to-pull-stream": "^1.7.2"
       },
@@ -10787,21 +11136,6 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        },
-        "multiaddr": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-4.0.0.tgz",
-          "integrity": "sha512-zUatrOCfBd/tJNOSoJ10d2EI2FDXB9PyPZhqUMdXE9mOyR3C+HLuOjga2Ga/eChwvEHIpTYRMoIKF2Nv7af2qQ==",
-          "requires": {
-            "bs58": "^4.0.1",
-            "class-is": "^1.1.0",
-            "ip": "^1.1.5",
-            "ip-address": "^5.8.9",
-            "lodash.filter": "^4.6.0",
-            "lodash.map": "^4.6.0",
-            "varint": "^5.0.0",
-            "xtend": "^4.0.1"
-          }
         }
       }
     },
@@ -10920,9 +11254,9 @@
           }
         },
         "libp2p-crypto": {
-          "version": "0.14.0",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.14.0.tgz",
-          "integrity": "sha512-NUIsh1z3uugidTC/hTIughvY2vih9wq+YHGIHKgMexWXyO6oJiDYsPw+I2Vh78/ULDZspfz3pdXPjgXueG/TEA==",
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.14.1.tgz",
+          "integrity": "sha512-JP3bfEzNik76fFIWOeU909+v76tjj5BMukbPCc61bgh1ixftcHkr4bH79duz+oSxRpGA+orCLxvkhgALV+pfwg==",
           "requires": {
             "asn1.js": "^5.0.1",
             "async": "^2.6.1",
@@ -10936,7 +11270,7 @@
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
-            "ursa-optional": "~0.9.8",
+            "ursa-optional": "~0.9.9",
             "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           }
         },
@@ -11008,6 +11342,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "ursa-optional": {
+          "version": "0.9.10",
+          "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.9.10.tgz",
+          "integrity": "sha512-RvEbhnxlggX4MXon7KQulTFiJQtLJZpSb9ZSa7ZTkOW0AzqiVTaLjI4vxaSzJBDH9dwZ3ltZadFiBaZslp6haA==",
+          "requires": {
+            "bindings": "^1.3.0",
+            "nan": "^2.11.1"
+          }
         }
       }
     },
@@ -11260,7 +11603,7 @@
       "requires": {
         "async": "^2.1.5",
         "find-process": "^1.0.5",
-        "fs-ext": "github:baudehlo/node-fs-ext#7c9824f3dc330e795aa13359d96252860bd3a684",
+        "fs-ext": "github:baudehlo/node-fs-ext#2ba366d9fc67ef3ab165e239068924b276ecf249",
         "nodeify": "^1.0.1",
         "once": "^1.4.0"
       }
@@ -11315,11 +11658,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
       "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
-    },
-    "lodash.flatten": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
@@ -11677,16 +12015,26 @@
       }
     },
     "memdown": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/memdown/-/memdown-3.0.0.tgz",
-      "integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
       "requires": {
-        "abstract-leveldown": "~5.0.0",
-        "functional-red-black-tree": "~1.0.1",
-        "immediate": "~3.2.3",
+        "abstract-leveldown": "~2.7.1",
+        "functional-red-black-tree": "^1.0.1",
+        "immediate": "^3.2.3",
         "inherits": "~2.0.1",
         "ltgt": "~2.2.0",
         "safe-buffer": "~5.1.1"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+          "requires": {
+            "xtend": "~4.0.0"
+          }
+        }
       }
     },
     "memoizerific": {
@@ -11745,6 +12093,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "merge-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz",
+      "integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
+      "requires": {
+        "is-plain-obj": "^1.1"
+      }
     },
     "merge-recursive": {
       "version": "0.0.3",
@@ -11846,29 +12202,6 @@
             "prr": "~1.0.1",
             "semver": "~5.4.1",
             "xtend": "~4.0.0"
-          }
-        },
-        "memdown": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
-          "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
-          "requires": {
-            "abstract-leveldown": "~2.7.1",
-            "functional-red-black-tree": "^1.0.1",
-            "immediate": "^3.2.3",
-            "inherits": "~2.0.1",
-            "ltgt": "~2.2.0",
-            "safe-buffer": "~5.1.1"
-          },
-          "dependencies": {
-            "abstract-leveldown": {
-              "version": "2.7.2",
-              "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
-              "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
-              "requires": {
-                "xtend": "~4.0.0"
-              }
-            }
           }
         },
         "semver": {
@@ -12235,13 +12568,21 @@
       }
     },
     "multihashing": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/multihashing/-/multihashing-0.3.2.tgz",
-      "integrity": "sha1-X+kNofgvuiu8dLaqtDJKZnAQH8k=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/multihashing/-/multihashing-0.3.3.tgz",
+      "integrity": "sha512-jXVWf5uqnZUhc1mLFPWOssuOpkj/A/vVLKrtEscD1PzSLobXYocBy9Gqa/Aw4229/heGnl0RBHU3cD53MbHUig==",
       "requires": {
-        "blakejs": "^1.0.1",
-        "multihashes": "~0.4.4",
-        "webcrypto": "~0.1.0"
+        "blakejs": "^1.1.0",
+        "js-sha3": "~0.8.0",
+        "multihashes": "~0.4.14",
+        "webcrypto": "~0.1.1"
+      },
+      "dependencies": {
+        "js-sha3": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+        }
       }
     },
     "multihashing-async": {
@@ -12323,9 +12664,9 @@
       }
     },
     "nanoid": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-1.3.1.tgz",
-      "integrity": "sha512-wSBw7t+JVjQAY8q89BhrTaBTMdoPGbZP8qQqidQHL76oeaFJ9i+c6SKKHP2l/DmzLP43eeV6JkM3f5Mb6saH8Q=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.0.0.tgz",
+      "integrity": "sha512-SG2qscLE3iM4C0CNzGrsAojJHSVHMS1J8NnvJ31P1lH8P0hGHOiafmniNJz6w6q7vuoDlV7RdySlJgtqkFEVtQ=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -12443,9 +12784,9 @@
       }
     },
     "node-abi": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.5.tgz",
-      "integrity": "sha512-aa/UC6Nr3+tqhHGRsAuw/edz7/q9nnetBrKWxj6rpTtm+0X9T1qU7lIEHMS3yN9JwAbRiKUbRRFy1PLz/y3aaA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.5.0.tgz",
+      "integrity": "sha512-9g2twBGSP6wIR5PW7tXvAWnEWKJDH/VskdXp168xsw9VVxpEGov8K4jsP4/VeoC7b2ZAyzckvMCuQuQlw44lXg==",
       "requires": {
         "semver": "^5.4.1"
       }
@@ -13383,21 +13724,22 @@
       }
     },
     "peer-star-app": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/peer-star-app/-/peer-star-app-0.8.0.tgz",
-      "integrity": "sha512-mRGmiIzG7nSZ4TF0EoruhuzkH6+md9R5PBv9GvKxKUCwWPPMqCgXvUIwmsR/gb55p0GNCSY8C5xDyQRoKFVckA==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/peer-star-app/-/peer-star-app-0.9.2.tgz",
+      "integrity": "sha512-a+dKIv6l1NjtlJKd+jCiBTwyrgA/Eib8mOVWbJHB8WeK/zClWTjSA6TpB7bcRxeChUBWrlHMUfp588kfZcaOAA==",
       "requires": {
         "asino": "~0.3.3",
+        "big-integer": "^1.6.36",
         "browser-process-hrtime": "^1.0.0",
-        "datastore-core": "~0.5.0",
+        "datastore-core": "~0.6.0",
         "debug": "^4.1.0",
         "delay": "^4.1.0",
-        "delta-crdts": "^0.5.0",
+        "delta-crdts": "^0.5.2",
         "delta-crdts-msgpack-codec": "^0.2.0",
         "frequency-counter": "^1.0.1",
-        "interface-datastore": "~0.5.0",
-        "ipfs": "0.32.3",
-        "ipfs-api": "^24.0.2",
+        "interface-datastore": "~0.6.0",
+        "ipfs": "0.33.0",
+        "ipfs-api": "^25.0.0",
         "leftpad": "0.0.1",
         "libp2p": "^0.23.1",
         "libp2p-bootstrap": "^0.9.3",
@@ -13427,9 +13769,9 @@
           }
         },
         "libp2p-crypto": {
-          "version": "0.14.0",
-          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.14.0.tgz",
-          "integrity": "sha512-NUIsh1z3uugidTC/hTIughvY2vih9wq+YHGIHKgMexWXyO6oJiDYsPw+I2Vh78/ULDZspfz3pdXPjgXueG/TEA==",
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.14.1.tgz",
+          "integrity": "sha512-JP3bfEzNik76fFIWOeU909+v76tjj5BMukbPCc61bgh1ixftcHkr4bH79duz+oSxRpGA+orCLxvkhgALV+pfwg==",
           "requires": {
             "asn1.js": "^5.0.1",
             "async": "^2.6.1",
@@ -13443,7 +13785,7 @@
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
-            "ursa-optional": "~0.9.8",
+            "ursa-optional": "~0.9.9",
             "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
           }
         },
@@ -13469,6 +13811,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.0.tgz",
           "integrity": "sha1-cT2LgY2kIGh0C/aDhtBHnmb8ins="
+        },
+        "ursa-optional": {
+          "version": "0.9.10",
+          "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.9.10.tgz",
+          "integrity": "sha512-RvEbhnxlggX4MXon7KQulTFiJQtLJZpSb9ZSa7ZTkOW0AzqiVTaLjI4vxaSzJBDH9dwZ3ltZadFiBaZslp6haA==",
+          "requires": {
+            "bindings": "^1.3.0",
+            "nan": "^2.11.1"
+          }
         }
       }
     },
@@ -14946,12 +15297,12 @@
       }
     },
     "prometheus-gc-stats": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/prometheus-gc-stats/-/prometheus-gc-stats-0.5.1.tgz",
-      "integrity": "sha1-RxO8Xp9znuCahslkAU37zk/VAAM=",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/prometheus-gc-stats/-/prometheus-gc-stats-0.6.0.tgz",
+      "integrity": "sha512-4kC+sGrSYT653/gDrnoeEISuM9wueSy524xvGzKpHA6Xf6xgTL5cpOxgBmrOyRDv8VvJPZ6lLTcRlBfmvOoeUw==",
       "optional": true,
       "requires": {
-        "gc-stats": "^1.0.0",
+        "gc-stats": "^1.2.0",
         "optional": "^0.1.3"
       }
     },
@@ -15180,12 +15531,12 @@
       "integrity": "sha512-CBkejkE5nX50SiSEzu0Qoz4POTJMS/mw8G6aj3h3M/RJoKgggLxyF0IyTZ0mmpXFlXRcLmLmIEW4xeYn7AeDYw=="
     },
     "pull-sort": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pull-sort/-/pull-sort-1.0.1.tgz",
-      "integrity": "sha1-qKsMcMhvRTQ8mszJOfxCdprT3G0=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pull-sort/-/pull-sort-1.0.2.tgz",
+      "integrity": "sha512-jGcAHMP+0Le+bEIhSODlbNNd3jW+S6XrXOlhVzfcKU5HQZjP92OzQSgHHSlwvWRsiTWi+UGgbFpL/5gGgmFoVQ==",
       "requires": {
-        "pull-defer": "^0.2.2",
-        "pull-stream": "^3.6.0"
+        "pull-defer": "^0.2.3",
+        "pull-stream": "^3.6.9"
       }
     },
     "pull-split": {
@@ -16506,6 +16857,25 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "rollbar-browser": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/rollbar-browser/-/rollbar-browser-1.9.5.tgz",
+      "integrity": "sha512-dE0Ni8I+Heekl6tRJnK4nlh1nWvS42guHz3ExTkbatzRkIBbM8QWgoqaZxI7gJpaKxu9AgjVRHhwkL8InfVLSQ==",
+      "dev": true,
+      "requires": {
+        "console-polyfill": "github:rollbar/console-polyfill#eab6ff9d2b7597fc2f259baa18100556bdb94dbe",
+        "error-stack-parser": "1.3.3",
+        "extend": "3.0.0"
+      },
+      "dependencies": {
+        "extend": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+          "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+          "dev": true
+        }
+      }
+    },
     "rsa-pem-to-jwk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/rsa-pem-to-jwk/-/rsa-pem-to-jwk-1.1.3.tgz",
@@ -16856,11 +17226,11 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
     },
     "shortid": {
-      "version": "2.2.13",
-      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.13.tgz",
-      "integrity": "sha512-dBuNnQGKrJNfjunmXI2X7bl1gnMO4PwbNxrTzO1JvilODmL7WyyCtA+DYxe9XunLXmxmgzFIvKPQ6XRAQrr46Q==",
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.14.tgz",
+      "integrity": "sha512-4UnZgr9gDdA1kaKj/38IiudfC3KHKhDc1zi/HSxd9FQDR0VLwH3/y79tZJLsVYPsJgIjeHjqIWaWVRJUj9qZOQ==",
       "requires": {
-        "nanoid": "^1.0.7"
+        "nanoid": "^2.0.0"
       }
     },
     "shot": {
@@ -17387,6 +17757,12 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
+    },
+    "stackframe": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz",
+      "integrity": "sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ=",
+      "dev": true
     },
     "standard": {
       "version": "11.0.1",
@@ -18536,9 +18912,9 @@
       }
     },
     "typeforce": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.15.1.tgz",
-      "integrity": "sha512-RYgFG+2GXx4V7guHOhW0cvryg/iWAoopbF/WlOI25YoV9rsOQ0E8bKfYAEZbJL0LJ8yVqcwp77tDG+oebBSNNw=="
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.16.0.tgz",
+      "integrity": "sha512-V60F7OHPH7vPlgIU73vYyeebKxWjQqCTlge+MvKlVn09PIhCOi/ZotowYdgREHB5S1dyHOr906ui6NheYXjlVQ=="
     },
     "ua-parser-js": {
       "version": "0.7.19",
@@ -18968,6 +19344,7 @@
       "version": "0.9.8",
       "resolved": "https://registry.npmjs.org/ursa-optional/-/ursa-optional-0.9.8.tgz",
       "integrity": "sha512-kYxw2g6fe9G/J2QG9CZH3FvVDvPXG8nw5X614zBjKZp7GI8e1jYobeNxxHElDu+dwEGleTJiT4ZxEa4j3OfPuA==",
+      "dev": true,
       "requires": {
         "bindings": "^1.3.0",
         "nan": "^2.10.0",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "puppeteer": "^1.9.0",
     "puppeteer-cluster": "^0.11.2",
     "react-test-renderer": "^15.6.2",
+    "rollbar-browser": "^1.9.5",
     "standard": "^11.0.1"
   },
   "jest": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import rollbar from 'rollbar-browser'
 import React from 'react'
 import ReactDOM from 'react-dom'
 // TODO: register service worker:
@@ -8,6 +9,20 @@ import 'tachyons-forms/css/tachyons-forms.css'
 import './index.styl'
 
 import App from './components/App'
+
+const rollbarConfig = {
+  // Only enable error reporting if user is loading the website via peerpad.net
+  enabled: window.location.hostname === 'peerpad.net',
+  accessToken: '2eaed8c2c5e243af8497d15ea90b407e',
+  captureUncaught: true,
+  captureUnhandledRejections: true,
+  payload: {
+    environment: process.env.NODE_ENV
+  }
+}
+const Rollbar = rollbar.init(rollbarConfig)
+window.Rollbar = Rollbar
+
 
 ReactDOM.render(<App />, document.getElementById('root'))
 // registerServiceWorker()


### PR DESCRIPTION
Adds reporting of errors when they happen on peerpad.net. We should
figure out if we want this to be opt-in or opt-out. Currently it's
neither and always enabled if peerpad is loaded via `peerpad.net`.

Relevant people have received an invitation to the rollbar project as
well.

License: MIT
Signed-off-by: Victor Bjelkholm <git@victor.earth>