### PR TITLE
Pass pinner args via environment variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "serve:build": "http-server -p 1337 build",
     "deploy:ipfs": "ipfs add -r build/",
     "start:rendezvous": "rendezvous",
-    "start:test:pinner": "pinner peer-pad/2 /dns4/127.0.0.1/tcp/9090/ws/p2p-websocket-star"
+    "start:test:pinner": "PEER_STAR_APP_NAME=peer-pad/2 PEER_STAR_SWARM_ADDRESS=/dns4/127.0.0.1/tcp/9090/ws/p2p-websocket-star pinner"
   },
   "dependencies": {
     "autoprefixer": "7.1.2",


### PR DESCRIPTION
I think this change is needed due to this change... https://github.com/ipfs-shipyard/peer-star-app/pull/147

My load test is still not completing though ... I'll investigate some more.