### PR TITLE
Set shouldComponentUpdate to false for codemirror binding

### DIFF
--- a/src/components/Edit.js
+++ b/src/components/Edit.js
@@ -297,14 +297,6 @@ class Edit extends Component {
     )
   }
 
-  componentDidUpdate () {
-    // Force codemirror to update to help avoid render / write order issues
-    if (this._editor && this._editor.refresh) {
-      this._editor.refresh()
-      this._editor.setOption('readOnly', !this.state.canEdit)
-    }
-  }
-
   async componentDidMount () {
     const PeerStar = await import('peer-star-app')
 
@@ -392,6 +384,10 @@ class Edit extends Component {
   maybeActivateEditor () {
     if (!this._editorBinding && this._editor) {
       this._editorBinding = bindEditor(this.state.doc, this._titleRef, this._editor, this.state.type)
+      if (this.state.canEdit) {
+        this._editor.setOption('readOnly', false)
+      }
+      this._editor.refresh()
     }
 
     // if (this._editor && this.state.canEdit) {

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -13,11 +13,19 @@ export default class Editor extends Component {
     this.onRef = this.onRef.bind(this)
   }
 
+  shouldComponentUpdate () {
+    return false
+  }
+
   onRef (ref) {
+    this.editorEle = ref
+  }
+
+  componentDidMount () {
     const { onEditor, onChange } = this.props
     let editor
 
-    if (ref) {
+    if (this.editorEle) {
       // if (type === 'richtext') {
       //   editor = new Quill(ref, {
       //     theme: 'bubble'
@@ -26,7 +34,7 @@ export default class Editor extends Component {
       //   editor.disable()
       // } else {
       // See: http://codemirror.net/doc/manual.html#config
-      editor = CodeMirror(ref, {
+      editor = CodeMirror(this.editorEle, {
         autofocus: true,
         inputStyle: 'contenteditable',
         lineNumbers: true,


### PR DESCRIPTION
Reduces the amount of react re-rendering.

Here are some videos to show the impact:

Before: https://gateway.ipfs.io/ipfs/QmV5UdKMTUbmVuz3nLrUSHLidroy8DaBZWZZ5EuB1wUZfH/react-before.mp4

After:
https://gateway.ipfs.io/ipfs/QmQJddeAsL2u8f3pUFwBTVoPTD82CvHwP3LvuB5YiiDEE7/react-after.mp4