### PR TITLE
Fix editor bindings lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1679,9 +1679,9 @@
       },
       "dependencies": {
         "hoek": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.1.tgz",
-          "integrity": "sha512-q60PigXXRtRFSe1+Eal3y/wlIq5weFsYPiyulkg1EAObgWhkDqSwj4xqgtd7qT3IpS6e4eLigyMWH6duPRI7QA=="
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
+          "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
         }
       }
     },
@@ -9934,9 +9934,9 @@
           },
           "dependencies": {
             "hoek": {
-              "version": "6.1.1",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.1.tgz",
-              "integrity": "sha512-q60PigXXRtRFSe1+Eal3y/wlIq5weFsYPiyulkg1EAObgWhkDqSwj4xqgtd7qT3IpS6e4eLigyMWH6duPRI7QA=="
+              "version": "6.1.2",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
+              "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
             }
           }
         }
@@ -10422,9 +10422,9 @@
           }
         },
         "hoek": {
-          "version": "6.1.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.1.tgz",
-          "integrity": "sha512-q60PigXXRtRFSe1+Eal3y/wlIq5weFsYPiyulkg1EAObgWhkDqSwj4xqgtd7qT3IpS6e4eLigyMWH6duPRI7QA=="
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
+          "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
         },
         "isemail": {
           "version": "3.2.0",
@@ -13753,9 +13753,9 @@
       }
     },
     "peer-star-app": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/peer-star-app/-/peer-star-app-0.10.3.tgz",
-      "integrity": "sha512-cdTN5zqqyhnmpzuPXmO2KjmwAw24NrHGVn3igY3OpR8nluwt/1OoOO4v2PZwK3oKqnsnOissXH2npFU3PN8Q4A==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/peer-star-app/-/peer-star-app-0.10.4.tgz",
+      "integrity": "sha512-vVh7CKxM4xLOkPtCQZNAMopuO0miS2LpDh3DYU8IyjiKyZGrgapte5oIeRQrL22GHmGWkyIDokLoAUzlyNmemQ==",
       "requires": {
         "asino": "~0.3.3",
         "big-integer": "^1.6.36",
@@ -13785,7 +13785,8 @@
         "multihashing": "~0.3.2",
         "p-queue": "^3.0.0",
         "peer-id": "~0.12.0",
-        "peer-info": "~0.14.1",
+        "peer-info": "~0.15.0",
+        "prom-client": "^11.2.0",
         "pull-pushable": "^2.2.0",
         "pull-stream": "^3.6.8",
         "vectorclock": "0.0.0"
@@ -13836,6 +13837,34 @@
             "multihashes": "~0.4.13",
             "murmurhash3js": "^3.0.1",
             "nodeify": "^1.0.1"
+          }
+        },
+        "peer-info": {
+          "version": "0.15.0",
+          "resolved": "https://registry.npmjs.org/peer-info/-/peer-info-0.15.0.tgz",
+          "integrity": "sha512-B4hpuSFv+So1sLyfn1FpEPaKDfyzZv10PEAJJC2HfJ9wrRMKT/YamnI9GciXI5xT/C604qKXC2XOkyPetNNapg==",
+          "requires": {
+            "lodash.uniqby": "^4.7.0",
+            "mafmt": "^6.0.2",
+            "multiaddr": "^5.0.2",
+            "peer-id": "~0.12.0"
+          },
+          "dependencies": {
+            "multiaddr": {
+              "version": "5.0.2",
+              "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-5.0.2.tgz",
+              "integrity": "sha512-dXz1chaUHV6L6okujDLS7uRA6NmCbitpikOJA0vMMnrwVyai5kC3ot2CSLrSfj3B8XIgNzpe/j5auSYrnbGGzA==",
+              "requires": {
+                "bs58": "^4.0.1",
+                "class-is": "^1.1.0",
+                "ip": "^1.1.5",
+                "ip-address": "^5.8.9",
+                "lodash.filter": "^4.6.0",
+                "lodash.map": "^4.6.0",
+                "varint": "^5.0.0",
+                "xtend": "^4.0.1"
+              }
+            }
           }
         },
         "tweetnacl": {
@@ -20481,7 +20510,7 @@
             },
             "hash.js": {
               "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+              "resolved": "http://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
               "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
               "requires": {
                 "inherits": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lodash.debounce": "^4.0.8",
     "milliseconds": "^1.0.3",
     "object-assign": "4.1.1",
-    "peer-star-app": "^0.10.3",
+    "peer-star-app": "^0.10.4",
     "pify": "^3.0.0",
     "postcss-css-variables": "^0.8.0",
     "postcss-flexbugs-fixes": "3.2.0",

--- a/src/lib/bind-editor.js
+++ b/src/lib/bind-editor.js
@@ -99,7 +99,7 @@ const bindCodeMirror = (doc, titleEditor, editor) => {
     locked = false
   }
 
-  doc.on('state changed', onStateChanged)
+  doc.shared.on('state changed', onStateChanged)
 
   editor.setValue(doc.shared.value().join(''))
 


### PR DESCRIPTION
Editor locking was presupposed on the `state changed` event emitted by the collaboration being synchronous to changes. Since peer-star-app v0.10.4 that's no longer the case.

Using the `state changed` event emitted by `collaboration.shared` instead.