### PR TITLE
Add APP_NAME_(DEV|PROD) and WEBSOCKET_STAR_(DEV|PROD)

### DIFF
--- a/src/components/Edit.js
+++ b/src/components/Edit.js
@@ -307,7 +307,15 @@ class Edit extends Component {
     if (!this._backend) {
       const peerStarConfig = window.__peerStarConfig ? window.__peerStarConfig : config.peerStar
       console.log('peer star config:', peerStarConfig)
-      this._backend = PeerStar(process.env.APP_NAME || 'peer-pad-dev', peerStarConfig)
+      this._backend = PeerStar(
+        (
+          process.env.APP_NAME ||
+          process.env.APP_NAME_DEV ||
+          process.env.APP_NAME_PROD ||
+          'peer-pad-dev'
+        ),
+        peerStarConfig
+      )
       this._backend.on('error', (err) => {
         console.error(err)
         window.alert(err.message)

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,8 @@ const NODE_ENV = process.env.NODE_ENV
 const isDev = NODE_ENV === 'development'
 
 const websocketStar = process.env.WEBSOCKET_STAR ||
+  process.env.WEBSOCKET_STAR_DEV ||
+  process.env.WEBSOCKET_STAR_PROD ||
   '/ip4/0.0.0.0/tcp/9090/ws/p2p-websocket-star'
 
 const defaultSwarmAddresses = {


### PR DESCRIPTION
process.env.APP_NAME and process.env.WEBSOCKET_STAR are overridden
in webpack (probably a bad pattern), so provide some alternatives
for when we provision on Heroku.